### PR TITLE
[STHUB-5] Added OTP support to get access token after log in.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,8 +14,8 @@
       <script src="index.js"></script>
       <script lang="js">
         const stripes = {
-          url: 'https://folio-etesting-snapshot-kong.ci.folio.org',
-          authnUrl: 'https://folio-etesting-snapshot-keycloak.ci.folio.org',
+         url: 'https://localhost:9130',
+          authnUrl: 'https://localhost:9131/auth'
         };
         const config = {
           tenantOptions: {

--- a/src/oidc-landing.html
+++ b/src/oidc-landing.html
@@ -11,7 +11,7 @@
         integrity="sha384-MTDrIlFOzEqpmOxY6UIA/1Zkh0a64UlmJ6R0UrZXqXCPx99siPGi8EmtQjIeCcTH"
         crossorigin="anonymous"></script>
       <script src="utils.js"></script>
-      <script src="index.js"></script>
+      <script src="oidcLanding.js"></script>
       <script lang="js">
         const stripes = {
           url: 'https://folio-etesting-snapshot-kong.ci.folio.org',
@@ -25,9 +25,10 @@
           },
           preserveConsole: true
         };
+
         const utils = new Utils(stripes, config);
-        const hub = new StripesHub(stripes, config, utils);
-        hub.init();
+        const oidcLanding = new OidcLanding(stripes, config, utils);
+        oidcLanding.init();
       </script>
   </head>
   <body>

--- a/src/oidc-landing.html
+++ b/src/oidc-landing.html
@@ -14,8 +14,8 @@
       <script src="oidcLanding.js"></script>
       <script lang="js">
         const stripes = {
-          url: 'https://folio-etesting-snapshot-kong.ci.folio.org',
-          authnUrl: 'https://folio-etesting-snapshot-keycloak.ci.folio.org',
+          url: 'https://localhost:9130',
+          authnUrl: 'https://localhost:9131/auth'
         };
         const config = {
           tenantOptions: {

--- a/src/oidcLanding.js
+++ b/src/oidcLanding.js
@@ -45,6 +45,7 @@ class OidcLanding {
       `${serverUrl}/users-keycloak/_self?expandPermissions=true&fullPermissions=true&overrideUser=true`,
       {
         headers: this.utils.getHeaders(tenant, token),
+        credentials: "include",
         rtrIgnore,
       },
     );
@@ -310,7 +311,7 @@ class OidcLanding {
           return this.utils.storeLogoutTenant(loginTenant.tenant);
         })
         .then(() => {
-          return this.requestUserWithPerms(this.stripes.url, loginTenant.tenant, this.utils.getCookie(FOLIO_ACCESS_TOKEN));
+          return this.requestUserWithPerms(this.stripes.url, loginTenant.tenant);
         });
     }
   };
@@ -328,7 +329,8 @@ class OidcLanding {
         params.append("redirect-uri", `${window.location.protocol}//${window.location.host}/oidc-landing.html?tenant=${loginTenant.name}&client_id=${loginTenant.clientId}`);
 
         const response = await fetch(`${this.stripes.url}/authn/token?${params}`, {
-          headers: this.utils.getHeaders(loginTenant.name)
+          headers: this.utils.getHeaders(loginTenant.name),
+          credentials: "include"
         });
 
         if (response.ok === false) {
@@ -336,7 +338,6 @@ class OidcLanding {
         }
 
         json = await response.json();
-        await this.utils.setCookieFromHttpResponse(response);
         // note: initSession is expected to execute an unawaited promise.
         // initSession calls .../_self and other functions in order to
         // populate the session, eventually dispatching redux actions

--- a/src/oidcLanding.js
+++ b/src/oidcLanding.js
@@ -1,0 +1,373 @@
+
+const atDefaultExpiration = Date.now() + (60 * 1000);
+const rtDefaultExpiration = Date.now() + (2 * 60 * 1000);
+
+// eslint-disable-next-line no-unused-vars
+class OidcLanding {
+  constructor(stripes, config, utils) {
+    this.stripes = stripes;
+    this.config = config;
+    this.utils = utils;
+  }
+
+  /**
+   * getLoginTenant
+   * Get the login tenant info from global config.
+   *
+   * @returns {object} tenant info object
+   */
+  getLoginTenant = () => {
+    const tenants = Object.values(this.config.tenantOptions);
+
+    // Selecting first for now until selection dropdown is added for multiple tenants
+    return tenants[0];
+  };
+
+  /**
+   * fetchOverriddenUserWithPerms
+   * When starting a session after turning from OIDC authentication, the user's current tenant
+   * (provided to X-Okapi-Tenant) may not match the central tenant. overrideUser=true query allow us to
+   * retrieve a real user's tenant permissions and service points even if X-Okapi-Tenant == central tenant.
+   * Example, we have user `exampleUser` that directly affiliated with `Member tenant` and for central tenant exampleUser is a shadow user.
+   * Previously, we had to log in to central tenant as a shadow user, and then switch the affiliation.
+   * But providing query overrideUser=true, we fetch the real user's tenant with its permissions and service points.
+   * Response looks like this, {originalTenantId: "Member tenant", permissions: {permissions: [...memberTenantPermissions]}, ...rest}.
+   * Now, we can set the originalTenantId to the session with fetched permissions and servicePoints.
+   * Compare with fetchUserWithPerms, which only fetches data from the current tenant, which is called during an established session when switching tenants.
+   * @param {string} serverUrl
+   * @param {string} tenant
+   * @param {string} token
+   *
+   * @returns {Promise} Promise resolving to the response-body (JSON) of the request
+   */
+  fetchOverriddenUserWithPerms = async (serverUrl, tenant, token, rtrIgnore = false) => {
+    const res = await fetch(
+      `${serverUrl}/users-keycloak/_self?expandPermissions=true&fullPermissions=true&overrideUser=true`,
+      {
+        headers: this.utils.getHeaders(tenant, token),
+        rtrIgnore,
+      },
+    );
+
+    return res;
+  };
+
+  /**
+   * handleLoginError
+   * Clear out session data, dispatch authentication errors, then dispatch
+   * okapi-ready to indicate that we're ready to start fresh. Return the
+   * response-body, er, JSON, from the failed auth-n request.
+   *
+   * @param {function} dispatch store.dispatch
+   * @param {Response} resp HTTP response from a failed auth-n request
+   *
+   * @returns {Promise} resolving to the response's JSON
+   */
+  handleLoginError = async (resp) => {
+    await localforage.removeItem(SESSION_NAME);
+    const responseBody = await this.utils.processBadResponse(resp);
+
+    return responseBody;
+  };
+
+  /**
+   * processSession
+   * create a new session with the response from either a username/password
+   * authentication request or a .../_self request.
+   * response body is shaped like
+   * {
+      'access_token': 'SOME_STRING',
+      'expires_in': 420,
+      'refresh_expires_in': 1800,
+      'refresh_token': 'SOME_STRING',
+      'token_type': 'Bearer',
+      'not-before-policy': 0,
+      'session_state': 'SOME_UUID',
+      'scope': 'profile email'
+  * }
+  *
+  * @param {string} tenant
+  * @param {Response} resp HTTP response
+  *
+  * @returns {Promise} resolving to login response body or undefined on error
+  */
+  processSession = async (tenant, resp, ssoToken) => {
+    if (resp.ok) {
+      const json = await resp.json();
+      const token = resp.headers.get('X-Okapi-Token') || json.access_token || ssoToken;
+      await this.createSession(tenant, token, json);
+      return json;
+    } else {
+      // handleLoginError will dispatch setAuthError, then resolve to undefined
+      return this.handleLoginError(resp);
+    }
+  };
+
+  /**
+   * spreadUserWithPerms
+   * Restructure the response from `bl-users/self?expandPermissions=true`
+   * to return an object shaped like
+   * {
+   *   user: { id, username, ...personal }
+   *   perms: { foo: true, bar: true, ... }
+   * }
+   *
+   * @param {object} userWithPerms
+   *
+   * @returns {object} { user, perms }
+   */
+  spreadUserWithPerms = (userWithPerms) => {
+    const user = {
+      id: userWithPerms?.user?.id,
+      username: userWithPerms?.user?.username,
+      ...userWithPerms?.user?.personal,
+    };
+
+    // remap data's array of permission-names to set with
+    // permission-names for keys and `true` for values.
+    //
+    // userWithPerms is shaped differently depending on the API call
+    // that generated it.
+    // in community-folio, /login sends data like [{ "permissionName": "foo" }]
+    //   and includes both directly and indirectly assigned permissions
+    // in community-folio, /_self sends data like ["foo", "bar", "bat"]
+    //   but only includes directly assigned permissions
+    // in community-folio, /_self?expandPermissions=true sends data like [{ "permissionName": "foo" }]
+    //   and includes both directly and indirectly assigned permissions
+    // in eureka-folio, /_self sends data like ["foo", "bar", "bat"]
+    //   and includes both directly and indirectly assigned permissions
+    //
+    // we'll parse it differently depending on what it looks like.
+    let perms = {};
+    const list = userWithPerms?.permissions?.permissions;
+    if (list && Array.isArray(list) && list.length > 0) {
+      // shaped like this ["foo", "bar", "bat"] or
+      // shaped like that [{ "permissionName": "foo" }]?
+      if (typeof list[0] === 'string') {
+        perms = Object.assign({}, ...list.map(p => ({ [p]: true })));
+      } else {
+        perms = Object.assign({}, ...list.map(p => ({ [p.permissionName]: true })));
+      }
+    }
+
+    return { user, perms };
+  };
+
+  /**
+   * createSession
+   * Remap the given data into a session object shaped like:
+   * {
+   *   user: { id, username, personal }
+   *   tenant: string,
+   *   perms: { permNameA: true, permNameB: true, ... }
+   *   isAuthenticated: boolean,
+   *   tokenExpiration: { atExpires, rtExpires }
+   * }
+   * Dispatch the session object, then return a Promise that fetches
+   * and dispatches tenant resources.
+   *
+   * @param {string} tenant tenant name
+   * @param {string} token access token [deprecated; prefer folioAccessToken cookie]
+   * @param {*} data response from call to _self
+   *
+   * @returns {Promise} resolving to { user, tenant, perms, isAuthenticated, tokenExpiration }
+   */
+  createSession = async (tenant, token, data) => {
+    const { user, perms } = this.spreadUserWithPerms(data);
+
+    // if we can't parse tokenExpiration data, e.g. because data comes from `.../_self`
+    // which doesn't provide it, then set an invalid AT value and a near-future (+10 minutes) RT value.
+    // the invalid AT will prompt an RTR cycle which will either give us new AT/RT values
+    // (if the RT was valid) or throw an RTR_ERROR (if the RT was not valid).
+    const tokenExpiration = {
+      atExpires: data.tokenExpiration?.accessTokenExpiration ? new Date(data.tokenExpiration.accessTokenExpiration).getTime() : -1,
+      rtExpires: data.tokenExpiration?.refreshTokenExpiration ? new Date(data.tokenExpiration.refreshTokenExpiration).getTime() : Date.now() + (10 * 60 * 1000),
+    };
+
+    /* @ See the comments for fetchOverriddenUserWithPerms.
+    * There are consortia(multi-tenant) and non-consortia modes/envs.
+    * We don't want to care if it is consortia or non-consortia modes, just use fetchOverriderUserWithPerms on login to initiate the session.
+    * 1. In consortia mode, fetchOverriderUserWithPerms returns originalTenantId.
+    * 2. In non-consortia mode, fetchOverriderUserWithPerms won't response with originalTenantId,
+    * instead `tenant` field will be provided.
+    * 3. As a fallback use default tenant.
+    */
+    const sessionTenant = data.originalTenantId || data.tenant || tenant;
+    const session = {
+      token,
+      isAuthenticated: true,
+      user,
+      perms,
+      tenant: sessionTenant,
+      tokenExpiration,
+    };
+
+    // localStorage events emit across tabs so we can use it like a
+    // BroadcastChannel to communicate with all tabs/windows.
+    // here, we set a dummy 'true' value just so we have something to
+    // remove (and therefore emit and respond to) on logout
+    localStorage.setItem(SESSION_NAME, 'true');
+
+    await localforage.setItem('loginResponse', data);
+    const sessionData = await localforage.getItem(SESSION_NAME);
+    // for keycloak-based logins, token-expiration data was already
+    // pushed to storage, so we pull it out and reuse it here.
+    // for legacy logins, token-expiration data is available in the
+    // login response.
+    if (sessionData?.tokenExpiration) {
+      session.tokenExpiration = sessionData.tokenExpiration;
+    } else if (data.tokenExpiration) {
+      session.tokenExpiration = {
+        atExpires: new Date(data.tokenExpiration.accessTokenExpiration).getTime(),
+        rtExpires: new Date(data.tokenExpiration.refreshTokenExpiration).getTime(),
+        accessTokenExpiration: data.tokenExpiration.accessTokenExpiration,
+        refreshTokenExpiration: data.tokenExpiration.refreshTokenExpiration,
+      };
+    } else {
+      // somehow, we ended up here without any legit token-expiration values.
+      // that's not great, but in theory we only ended up here as a result
+      // of logging in, so let's punt and assume our cookies are valid.
+      // set an expired AT and RT 10 minutes into the future; the expired
+      // AT will kick off RTR, and on success we'll store real values as a result,
+      // or on failure we'll get kicked out. no harm, no foul.
+      session.tokenExpiration = {
+        atExpires: -1,
+        rtExpires: Date.now() + (10 * 60 * 1000),
+      };
+    }
+
+    await localforage.setItem(SESSION_NAME, session);
+
+    console.log('TODO: load Stripes here', session);
+    //await this.loadResources(store, sessionTenant, user.id);
+  };
+
+  /**
+   * requestUserWithPerms
+   * retrieve currently-authenticated user, then process the result to begin a session.
+   * @param {string} serverUrl
+   * @param {string} tenant
+   * @param {string} token
+   *
+   * @returns {Promise} Promise resolving to the response-body (JSON) of the request
+   */
+  requestUserWithPerms = async (serverUrl, tenant, token) => {
+    const resp = await this.fetchOverriddenUserWithPerms(serverUrl, tenant, token, !token);
+
+    if (resp.ok) {
+      const sessionData = await this.processSession(tenant, resp, token);
+      return sessionData;
+    } else {
+      const error = await resp.json();
+      throw error;
+    }
+  }
+
+  /**
+   * setTokenExpiry
+   * simple wrapper around access to values stored in localforage
+   * to insulate RTR functions from that API. Supplement the existing
+   * session with updated token expiration data. Given values (millisecond
+   * timestamps) are persisted as-is; corresponding human-readable values
+   * (accessTokenExpiration, refreshTokenExpiration) are written as well.
+   *
+   * @param {object} shaped like { atExpires, rtExpires }; each is a millisecond timestamp
+   * @returns {Promise} resolving to updated session object
+   */
+  setTokenExpiry = async (te) => {
+    if (Number.isInteger(te.atExpires) && Number.isInteger(te.rtExpires)) {
+      const tokenExpiration = {
+        ...te,
+        accessTokenExpiration: new Date(te.atExpires).toISOString(),
+        refreshTokenExpiration: new Date(te.rtExpires).toISOString(),
+      };
+
+      const sess = await this.utils.getSession();
+      const val = { ...sess, tokenExpiration };
+      return localforage.setItem(SESSION_NAME, val);
+    }
+
+    // eslint-disable-next-line no-console
+    console.error('Expected { atExpires: int, rtExpires: int }; received', te);
+    return Promise.reject(new TypeError('Did not receive { atExpires: int, rtExpires: int }'));
+  };
+
+  /**
+   * initSession
+   * Callback for useExchangeCode to execute after exchanging the OTP
+   * for token-expiration data and cookies
+   * @param {object} tokenData shaped like { accessTokenExpiration, refreshTokenExpiration}
+   */
+  initSession = (tokenData) => {
+    const loginTenant = this.utils.getLoginTenant();
+
+    if (tokenData) {
+      this.setTokenExpiry({
+        atExpires: tokenData.accessTokenExpiration ? new Date(tokenData.accessTokenExpiration).getTime() : atDefaultExpiration,
+        rtExpires: tokenData.refreshTokenExpiration ? new Date(tokenData.refreshTokenExpiration).getTime() : rtDefaultExpiration,
+      })
+        .then(() => {
+          return this.utils.storeLogoutTenant(loginTenant.tenant);
+        })
+        .then(() => {
+          return this.requestUserWithPerms(this.stripes.url, loginTenant.tenant, this.utils.getCookie(FOLIO_ACCESS_TOKEN));
+        });
+    }
+  };
+
+  useExchangeCode = async () => {
+    let json = {};
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+    const loginTenant = this.getLoginTenant();
+
+    if (code) {
+      try {
+        const params = new URLSearchParams();
+        params.append("code", code);
+        params.append("redirect-uri", `${window.location.protocol}//${window.location.host}/oidc-landing.html?tenant=${loginTenant.name}&client_id=${loginTenant.clientId}`);
+
+        const response = await fetch(`${this.stripes.url}/authn/token?${params}`, {
+          headers: this.utils.getHeaders(loginTenant.name)
+        });
+
+        if (response.ok === false) {
+          throw { response };
+        }
+
+        json = await response.json();
+        await this.utils.setCookieFromHttpResponse(response);
+        // note: initSession is expected to execute an unawaited promise.
+        // initSession calls .../_self and other functions in order to
+        // populate the session, eventually dispatching redux actions
+        // (isAuthenticated, sessionData, okapiReady), triggering
+        // RootWithIntl to re-render.
+        //
+        // return the json response from `authn/token` in order to
+        // show a status update on the calling page while session-init
+        // is still in-flight.
+        this.initSession(json);
+      } catch (fetchError) {
+        // throw json from the error-response, or just rethrow
+        if (fetchError?.response?.json) {
+          const errorJson = await fetchError.response.json();
+          throw errorJson;
+        }
+
+        throw fetchError;
+      }
+    } else {
+
+      // eslint-disable-next-line no-throw-literal
+      throw new Error('OTP code is missing');
+    }
+
+    return json;
+  };
+
+  init = async () => {
+    const token = await this.useExchangeCode();
+    console.log('OIDC Redirect completed, token:', token);
+    return token;
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,161 @@
+/** name for the session key in local storage */
+const SESSION_NAME = 'okapiSess';
+
+/** name for the folio access token cookie */
+const FOLIO_ACCESS_TOKEN = 'folioAccessToken';
+
+/** key for the logging out action */
+const IS_LOGGING_OUT = '@folio/stripes/core::Logout';
+
+/**
+ * dispatched if the session is idle (without activity) for too long
+ */
+const RTR_TIMEOUT_EVENT = '@folio/stripes/core::RTRIdleSessionTimeout';
+
+/** key for storing tenant info in local storage */
+const TENANT_LOCAL_STORAGE_KEY = 'tenant';
+
+/** key for login response in local storage */
+const LOGIN_RESPONSE = 'loginResponse';
+
+/** path to users API call */
+const USERS_PATH = 'users-keycloak';
+
+class Utils {
+  constructor(stripes, config) {
+    this.stripes = stripes;
+    this.config = config;
+  }
+
+  /**
+   * getHeaders
+   * Construct headers for FOLIO requests.
+   *
+   * @param {string} tenant the tenant name
+   * @param {string} token the auth token
+   * @returns {object} headers for FOLIO requests
+   */
+  getHeaders = (tenant, token) => {
+    return {
+      'X-Okapi-Tenant': tenant,
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      ...(token && { 'X-Okapi-Token': token }),
+    };
+  };
+
+  /**
+   * getCookie
+   * Retrieve a cookie value by name.
+   * Based on code from https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+   * 
+   * @param {string} name 
+   */
+  getCookie = (name) => {
+    document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`))
+    ?.split("=")[1];
+  };
+
+  /**
+   * setCookieFromHttpResponse
+   * Set cookies from the response headers.
+   *
+   * @param {Response} response the fetch response object
+   */
+  setCookieFromHttpResponse = (response) => {
+    for (const entry of response.headers.entries()) {
+      //const rawCookies = response.headers.getSetCookie();
+      if (entry[0].toLowerCase() === 'set-cookie') {
+        entry[1].split(',').forEach(cookieStr => {
+          document.cookie = cookieStr;
+        });
+      }
+    }
+  };
+
+  /**
+   * getSession
+   * simple wrapper around access to values stored in localforage
+   * to insulate RTR functions from that API.
+   *
+   * @returns {object} Session object from localforage
+  */
+  getSession = () => {
+    return localforage.getItem(SESSION_NAME);
+  };
+
+  /**
+   * getLoginTenant
+   * Retrieve tenant and clientId values. In order of preference, look here:
+   *
+   * 1 the URL for params named tenant and client_id
+   * 2 stripes.config.js::config::tenantOptions iff it contains a single tenant,
+   *   i.e. if it is shaped like this:
+   *   tenantOptions: { someT: { name: 'someT', clientId: 'someC' }}
+   * 3 stripes.config.js::okapi, the deprecated-but-historical location of these
+   *   values
+   *
+   * @param {*} stripesConfig stripes.config.js::config
+   * @returns { tenant: string, clientId: string }
+   */
+  getLoginTenant = (stripesConfig) => {
+    // derive from the URL
+    const urlParams = new URLSearchParams(window.location.search);
+    let tenant = urlParams.get('tenant');
+    let clientId = urlParams.get('client_id');
+
+    // derive from stripes.config.js::config::tenantOptions
+    if (stripesConfig?.tenantOptions && Object.keys(stripesConfig?.tenantOptions).length === 1) {
+      const key = Object.keys(stripesConfig.tenantOptions)[0];
+      tenant ||= stripesConfig.tenantOptions[key]?.name;
+      clientId ||= stripesConfig.tenantOptions[key]?.clientId;
+    }
+
+    // default to stripes.config.js::okapi
+    tenant ||= stripesOkapi?.tenant;
+    clientId ||= stripesOkapi?.clientId;
+
+    return {
+      tenant,
+      clientId,
+    };
+  };
+
+  /**
+   * getLogoutTenant
+   * Retrieve the tenant ID from local storage for use during logout.
+   *
+   * @returns {object|undefined} tenant info object or undefined if not found
+   */
+  getLogoutTenant = () => {
+    const storedTenant = localStorage.getItem(TENANT_LOCAL_STORAGE_KEY);
+    return storedTenant ? JSON.parse(storedTenant) : undefined;
+  };
+
+  /**
+   * storeLogoutTenant
+   * Store the tenant ID in local storage for use during logout.
+   *
+   * @param {string} tenantId the tenant ID
+   */
+  storeLogoutTenant = (tenantId) => {
+    localStorage.setItem(TENANT_LOCAL_STORAGE_KEY, JSON.stringify({ tenantId }));
+  };
+
+  processBadResponse = async (response, defaultClientError) => {
+    const clientError = defaultClientError || defaultErrors.DEFAULT_LOGIN_CLIENT_ERROR;
+    let actionPayload;
+
+    try {
+      const responseBody = await response.json();
+      const responsePayload = responseBody.errorMessage || responseBody;
+      actionPayload = getProcessedErrors(responsePayload, response.status, clientError);
+    } catch (e) {
+      actionPayload = [defaultErrors.DEFAULT_LOGIN_CLIENT_ERROR];
+    }
+
+    return actionPayload;
+  };
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,6 @@
 /** name for the session key in local storage */
 const SESSION_NAME = 'okapiSess';
 
-/** name for the folio access token cookie */
-const FOLIO_ACCESS_TOKEN = 'folioAccessToken';
-
 /** key for the logging out action */
 const IS_LOGGING_OUT = '@folio/stripes/core::Logout';
 
@@ -42,37 +39,6 @@ class Utils {
       'Content-Type': 'application/json',
       ...(token && { 'X-Okapi-Token': token }),
     };
-  };
-
-  /**
-   * getCookie
-   * Retrieve a cookie value by name.
-   * Based on code from https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
-   * 
-   * @param {string} name 
-   */
-  getCookie = (name) => {
-    document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(`${name}=`))
-    ?.split("=")[1];
-  };
-
-  /**
-   * setCookieFromHttpResponse
-   * Set cookies from the response headers.
-   *
-   * @param {Response} response the fetch response object
-   */
-  setCookieFromHttpResponse = (response) => {
-    for (const entry of response.headers.entries()) {
-      //const rawCookies = response.headers.getSetCookie();
-      if (entry[0].toLowerCase() === 'set-cookie') {
-        entry[1].split(',').forEach(cookieStr => {
-          document.cookie = cookieStr;
-        });
-      }
-    }
   };
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -113,10 +113,6 @@ class Utils {
       clientId ||= stripesConfig.tenantOptions[key]?.clientId;
     }
 
-    // default to stripes.config.js::okapi
-    tenant ||= stripesOkapi?.tenant;
-    clientId ||= stripesOkapi?.clientId;
-
     return {
       tenant,
       clientId,


### PR DESCRIPTION
- Fulfills [STHUB-5](https://folio-org.atlassian.net/browse/STHUB-5).
- Added `oidc-landing.html` to handle post-login redirect route `/oidc-landing`. Config is duplicated here, so open to suggestions to improve this.
- Moved common code to `utils.js`. 
- Added cookie support and store resulting session in `localforage`.