### PR TITLE
DRAFT: STHUB-3 Load separately hosted stripes bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,16 @@
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "scripts": {
-    "start": "stripes serve",
+    "start": "yarn serve -C ./src -l 3001",
     "test": "jest --ci --coverage --colors",
     "lint": "eslint . "
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/jest-config-stripes": "^3.0.0",
-    "@folio/stripes-cli": "^4.0.0"
+    "@folio/stripes-cli": "^4.0.0",
+    "serve": "^14.2.5"
   },
-  "dependencies": {
-  },
-  "peerDependencies": {
-  }
+  "dependencies": {},
+  "peerDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
   "scripts": {
-    "start": "yarn serve -C ./src -l 3001",
+    "start": "yarn serve -C ./src -l 3010",
     "test": "jest --ci --coverage --colors",
     "lint": "eslint . "
   },

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
@@ -7,28 +8,31 @@
   <meta http-equiv="Expires" content="0" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>FOLIO</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/localforage/1.10.0/localforage.min.js"
-      integrity="sha384-MTDrIlFOzEqpmOxY6UIA/1Zkh0a64UlmJ6R0UrZXqXCPx99siPGi8EmtQjIeCcTH"
-      crossorigin="anonymous"></script>
-    <script src="index.js"></script>
-    <script lang="js">
-      const stripes = {
-        url: 'https://folio-etesting-snapshot-kong.ci.folio.org',
-        authnUrl: 'https://folio-etesting-snapshot-keycloak.ci.folio.org',
-      };
-      const config = {
-        tenantOptions: {
-          diku: {
-            name: 'diku', clientId: 'diku-application'
-          }
-        },
-        preserveConsole: true
-      };
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/localforage/1.10.0/localforage.min.js"
+    integrity="sha384-MTDrIlFOzEqpmOxY6UIA/1Zkh0a64UlmJ6R0UrZXqXCPx99siPGi8EmtQjIeCcTH"
+    crossorigin="anonymous"></script>
+  <script src="index.js"></script>
+  <script lang="js">
+    const stripes = {
+      url: 'https://folio-etesting-snapshot-kong.ci.folio.org',
+      authnUrl: 'https://folio-etesting-snapshot-keycloak.ci.folio.org',
+    };
+    const config = {
+      tenantOptions: {
+        diku: {
+          name: 'diku', clientId: 'diku-application'
+        }
+      },
+      preserveConsole: true
+    };
 
-      const hub = new StripesHub(stripes, config);
-      hub.init();
-    </script>
+    const hub = new StripesHub(stripes, config);
+    hub.init();
+  </script>
 </head>
+
 <body>
+  <div id="root"></div>
 </body>
+
 </html>


### PR DESCRIPTION
Obviously some of the important guts are commented out to get this working, but the basics:

`loadStripes` has a hard-coded location of the stripes-to-be-loaded.
It pushes this value to `localforage` under the `hostLocation` key... this is subject to change.

it loads the manifest.json. It parses the manifest.json. It collects the necessary items...
It injects the styles via `link` tags...
it summons the bundle via native `import` :)

