### PR TITLE
[STHUB-18] Store stripes-config and branding data in localforage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 * [STHUB-1](https://folio-org.atlassian.net/browse/STHUB-1) Added config and logic for session validation. If session is invalid, redirect to keycloak login page.
+* [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store stripes-config and branding data in localforage to override stripes.config.js values (or absence of stripes.config.js).
 
 ## 1.0.0
 

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
 
-function StripesHub({ config }) {
-  const { isLoading } = useInitSession(config, urlPaths.AUTHN_LOGIN);
+function StripesHub({ config, branding }) {
+  const { isLoading } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
 
   return (
     <div data-testid="StripesHub">
@@ -20,6 +20,10 @@ StripesHub.propTypes = {
     discoveryUrl: PropTypes.string,
     tenantOptions: PropTypes.object.isRequired,
     preserveConsole: PropTypes.bool,
+  }).isRequired,
+  branding: PropTypes.shape({
+    logo: PropTypes.string,
+    altText: PropTypes.string,
   }).isRequired,
 };
 

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -9,7 +9,7 @@ import {
   USERS_PATH,
 } from '../loginServices';
 
-const useInitSession = async (config, loginUrl) => {
+const useInitSession = async (config, branding, loginUrl) => {
 
   const getSessionTenant = (session) => {
     return session.tenant;
@@ -87,7 +87,7 @@ const useInitSession = async (config, loginUrl) => {
           // even though it's async, we do not await it here, instead
           // returning the response-json that can be used to show a status
           // update while session-init is still in-flight.
-          initStripes(config, sessionTenant);
+          initStripes(config, branding, sessionTenant);
 
           return session;
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 const config = FOLIO_CONFIG || {}; // eslint-disable-line no-undef
 const branding = BRANDING_GLOBAL || {}; // eslint-disable-line no-undef
 const AuthnLoginComponent = () => <AuthnLogin config={config} branding={branding} />;
-const OidcLandingComponent = () => <OidcLanding config={config} branding={branding} />;
+const OidcLandingComponent = () => <OidcLanding config={config} />;
 const StripesHubComponent = () => <StripesHub config={config} branding={branding} />;
 
 const reactQueryClient = createReactQueryClient();

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -26,6 +26,12 @@ export const USERS_PATH = 'users-keycloak';
 /** name for whatever the entitlement service will call the hub app (stripes, stripes-core, etc.) */
 const HOST_APP_NAME = 'folio_stripes';
 
+/** name for FOLIO config stored in localforage to be used by entitled applications (such as stripes-core) */
+const FOLIO_CONFIG_KEY = 'folio_config';
+
+/** name for FOLIO branding file locations to be used by entitled applications (such as stripes-core) */
+const FOLIO_BRANDING_KEY = 'folio_branding';
+
 // const keys to-be-ingested by stripes-core
 const DISCOVERY_URL_KEY = 'discoveryUrl';
 const HOST_LOCATION_KEY = 'hostLocation';
@@ -351,17 +357,20 @@ const loadStripes = async (stripesCore) => {
  * discovery data to find stripes' location.
  *
  * @param {object} config
+ * @param {object} branding
  * @param {string} tenant
  * @returns {Promise<void>} resolves when stripes is initialized
  */
-export const initStripes = async (config, tenant) => {
+export const initStripes = async (config, branding, tenant) => {
   const entitlement = await fetchEntitlements(config, tenant);
   const discovery = await fetchDiscovery(config, tenant, entitlement);
 
   const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
   if (stripesCore) {
     await localforage.setItem(DISCOVERY_URL_KEY, config.discoveryUrl ?? config.gatewayUrl);
-    await localforage.setItem(HOST_APP_NAME, 'folio_stripes');
+    await localforage.setItem(HOST_APP_NAME, HOST_APP_NAME);
+    await localforage.setItem(FOLIO_CONFIG_KEY, config);
+    await localforage.setItem(FOLIO_BRANDING_KEY, branding);
     await localforage.setItem(HOST_LOCATION_KEY, stripesCore.location);
 
     // REMOTE_LIST_KEY stores the list of apps that stripes will load,


### PR DESCRIPTION
- Fulfills [STHUB-18] (https://folio-org.atlassian.net/browse/STHUB-18).
- Allows values to be read by `stripes-core` to override `stripes.config.js` values or absence of `stripes.config.js`.