### PR TITLE
[STHUB-18] Store stripes-config and branding data in localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 * [STHUB-1](https://folio-org.atlassian.net/browse/STHUB-1) Added config and logic for session validation. If session is invalid, redirect to keycloak login page.
-* [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store stripes-config and branding data in localforage to override stripes.config.js values (or absence of stripes.config.js).
+* [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store stripes-config and branding data in localStorage to override stripes.config.js values (or absence of stripes.config.js).
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 * [STHUB-1](https://folio-org.atlassian.net/browse/STHUB-1) Added config and logic for session validation. If session is invalid, redirect to keycloak login page.
-* [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store stripes-config and branding data in localStorage to override stripes.config.js values (or absence of stripes.config.js).
+* [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store config and branding data from index.html in localstorage for consumption by stripes, which may be built independently.
 
 ## 1.0.0
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link rel="icon" href="%PUBLIC_URL%/folio-favicon.img" />
+    <link rel="icon" href="%PUBLIC_URL%/folio-favicon.png" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <link rel="icon" href="%PUBLIC_URL%/folio-favicon.png" />
+    <link rel="icon" href="%PUBLIC_URL%/tenant-assets/folio-favicon.png" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/AuthnLogin.js
+++ b/src/AuthnLogin.js
@@ -39,8 +39,13 @@ AuthnLogin.propTypes = {
     tenantOptions: PropTypes.object.isRequired,
   }).isRequired,
   branding: PropTypes.shape({
-    logo: PropTypes.string,
-    altText: PropTypes.string,
+    logo: PropTypes.shape({
+      src: PropTypes.string,
+      alt: PropTypes.string,
+    }),
+    favicon: PropTypes.shape({
+      src: PropTypes.string,
+    }),
   }),
 };
 

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -22,8 +22,13 @@ StripesHub.propTypes = {
     preserveConsole: PropTypes.bool,
   }).isRequired,
   branding: PropTypes.shape({
-    logo: PropTypes.string,
-    altText: PropTypes.string,
+    logo: PropTypes.shape({
+      src: PropTypes.string,
+      alt: PropTypes.string,
+    }),
+    favicon: PropTypes.shape({
+      src: PropTypes.string,
+    }),
   }).isRequired,
 };
 

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -367,10 +367,12 @@ export const initStripes = async (config, branding, tenant) => {
 
   const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
   if (stripesCore) {
+    // cache config and branding data for stripes-core to consume on load
+    localStorage.setItem(FOLIO_CONFIG_KEY, JSON.stringify(config));
+    localStorage.setItem(FOLIO_BRANDING_KEY, JSON.stringify(branding));
+
     await localforage.setItem(DISCOVERY_URL_KEY, config.discoveryUrl ?? config.gatewayUrl);
     await localforage.setItem(HOST_APP_NAME, HOST_APP_NAME);
-    await localforage.setItem(FOLIO_CONFIG_KEY, config);
-    await localforage.setItem(FOLIO_BRANDING_KEY, branding);
     await localforage.setItem(HOST_LOCATION_KEY, stripesCore.location);
 
     // REMOTE_LIST_KEY stores the list of apps that stripes will load,

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -378,7 +378,7 @@ export const initStripes = async (config, branding, tenant) => {
   const entitlement = await fetchEntitlements(config, tenant);
   const discovery = await fetchDiscovery(config, tenant, entitlement);
 
-  let stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
+  const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
   if (stripesCore) {
     //stripesCore.location = "http://stripes-force-host.s3.us-east-1.amazonaws.com";
     // cache config and branding data for stripes-core to consume on load

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -379,8 +379,8 @@ export const initStripes = async (config, branding, tenant) => {
   const discovery = await fetchDiscovery(config, tenant, entitlement);
 
   const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
+
   if (stripesCore) {
-    //stripesCore.location = "http://stripes-force-host.s3.us-east-1.amazonaws.com";
     // cache config and branding data for stripes-core to consume on load
     localStorage.setItem(FOLIO_CONFIG_KEY, JSON.stringify(config));
     localStorage.setItem(FOLIO_BRANDING_KEY, JSON.stringify(branding));

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -206,8 +206,8 @@ const fetchEntitlements = async (config, tenant) => {
     application.uiModuleDescriptors.forEach(module => {
       if (entitlement[module.id]) {
 
-        entitlement[module.id].okapiInterfaces = module.requires;
-        entitlement[module.id].optionalOkapiInterfaces = module.optional;
+        entitlement[module.id].okapiInterfaces = interfaceArrayToKeyedObject(module.requires || []);
+        entitlement[module.id].optionalOkapiInterfaces = interfaceArrayToKeyedObject(module.optional || []);
         entitlement[module.id] = { ...entitlement[module.id], ...module.metadata?.stripes };
       }
     });
@@ -215,6 +215,19 @@ const fetchEntitlements = async (config, tenant) => {
 
   return entitlement;
 };
+
+/**
+ * Helper function to convert an array of objects with `id` and `version`
+ * properties into an object keyed by `id` with values of `version`.
+ * @param {*} arr the array of interfaces to convert shaped like [{ id: 'interfaceA', version: '1.0 2.0' }, ...]
+ * @returns the converted object shaped like { interfaceA: '1.0 2.0', ... }
+ */
+const interfaceArrayToKeyedObject = (arr) => {
+    return arr.reduce((acc, curr) => {
+        acc[curr.id] = curr.version;
+        return acc;
+    }, {});
+}
 
 /**
  * fetchCustomDiscovery
@@ -365,8 +378,9 @@ export const initStripes = async (config, branding, tenant) => {
   const entitlement = await fetchEntitlements(config, tenant);
   const discovery = await fetchDiscovery(config, tenant, entitlement);
 
-  const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
+  let stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
   if (stripesCore) {
+    //stripesCore.location = "http://stripes-force-host.s3.us-east-1.amazonaws.com";
     // cache config and branding data for stripes-core to consume on load
     localStorage.setItem(FOLIO_CONFIG_KEY, JSON.stringify(config));
     localStorage.setItem(FOLIO_BRANDING_KEY, JSON.stringify(branding));


### PR DESCRIPTION
- Fulfills [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18).
- Switch from `localforage` to `localStorage` since `localforage` requires `async` which does not work in stripes-core constuctor functions. 
- Made a few other nitpick changes to fix the favicon reference and the shape of `okapiInterfaces` data to match what is expected on the `Settings -> Sofrware Versions` page (and what stripes-core uses).
- stripes-core work to consume is completed in https://github.com/folio-org/stripes-core/pull/1700.