### PR TITLE
STHUB-11 💀 handle fatal startup errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0 (IN PROGRESS)
 * [STHUB-1](https://folio-org.atlassian.net/browse/STHUB-1) Added config and logic for session validation. If session is invalid, redirect to keycloak login page.
 * [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store stripes-config and branding data in localforage to override stripes.config.js values (or absence of stripes.config.js).
+* [STHUB-11](https://folio-org.atlassian.net/browse/STHUB-11) Trap errors during entitlement, discovery, and the loading of Stripes.
 
 ## 1.0.0
 

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -2,7 +2,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
-import Template from './Template';
+import StripesTemplate from './StripesTemplate';
 import styles from './index.css';
 
 
@@ -39,7 +39,7 @@ function FatalError({ branding, config, error }) {
   const l10nMessage = error.options?.id ? intl.formatMessage({ id: error.options.id }, { url: error?.options?.url }) : error.message;
 
   return (
-    <Template branding={branding}>
+    <StripesTemplate branding={branding}>
       <Row center="xs">
         <Col xs={12}>
           <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
@@ -66,7 +66,7 @@ function FatalError({ branding, config, error }) {
           </Button>
         </Col>
       </Row>
-    </Template>
+    </StripesTemplate>
 
   );
 }

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { useIntl } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
+import { getLoginUrl, getCurrentTenant } from './loginServices';
+import styles from './index.css';
+
+
+function FatalError({ branding, config, error }) {
+  const intl = useIntl();
+  const [message, setMessage] = useState();
+  const [subMessage, setSubMessage] = useState();
+
+  const handleLogout = async () => {
+    await fetch(`${config.gatewayUrl}/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    }); // eslint-disable-line no-unused-vars
+    globalThis.location.assign(location.origin);
+  }
+
+  const handleReload = () => {
+    location.reload();
+  }
+
+  if (error?.options?.json) {
+    if (error?.options.json?.errors[0]?.message) {
+      setMessage(error.options.json?.errors[0]?.message);
+      const params = error.options.json.errors[0]?.parameters;
+      if (params && params[0]?.value) {
+        setSubMessage(params[0].value);
+      }
+    }
+  }
+
+  return (
+    <main style={{ width: '100%' }}>
+      <div>
+        <div className={styles.container}>
+          <Row center="xs">
+            <Col xs={12}>
+              <OrganizationLogo branding={branding} />
+            </Col>
+          </Row>
+          <Row center="xs">
+            <Col xs={12}>
+              <h1>Rats. You successfully signed in, but FOLIO failed to load because of an error 😢</h1>
+              <h2>{error.message}</h2>
+              <h3>{message}</h3>
+              <h3>{subMessage}</h3>
+            </Col>
+          </Row>
+          <Row center="xs">
+            <Col xs={6}>
+              <Button
+                className={styles.submitButton}
+                onClick={handleReload}
+              >
+                Try again
+              </Button>
+            </Col>
+            <Col xs={6}>
+              <Button
+                className={styles.submitButton}
+                onClick={handleLogout}
+              >
+                Logout
+              </Button>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+FatalError.propTypes = {
+  branding: PropTypes.shape({
+    logo: PropTypes.string,
+    altText: PropTypes.string,
+  }).isRequired,
+  error: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    cause: PropTypes.shape({ message: PropTypes.string.isRequired }),
+  }).isRequired
+};
+
+export default FatalError;

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -1,9 +1,10 @@
 import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
+import { Button, Col, Row } from './StripesComponents';
 import StripesTemplate from './StripesTemplate';
 import styles from './index.css';
+import { config } from 'localforage';
 
 
 function FatalError({ branding, config, error }) {
@@ -25,13 +26,9 @@ function FatalError({ branding, config, error }) {
   // did we get some juicy json in an API response?
   let message = null;
   let subMessage = null;
-  const errors = error?.options?.json?.errors;
-  if (errors && errors[0]?.message) {
-    message = errors[0]?.message;
-    const params = errors[0]?.parameters;
-    if (params && params[0]?.value) {
-      subMessage = params[0].value;
-    }
+  if (error?.options?.json?.errors?.[0]?.message) {
+    message = error?.options?.json?.errors[0]?.message;
+    subMessage = error?.options?.json?.errors[0]?.parameters?.[0].value;
   } else if (error?.options?.json?.message) {
     message = error?.options?.json?.message;
   }
@@ -73,12 +70,28 @@ function FatalError({ branding, config, error }) {
 
 FatalError.propTypes = {
   branding: PropTypes.shape({
-    logo: PropTypes.string,
     altText: PropTypes.string,
+    logo: PropTypes.string,
+  }).isRequired,
+  config: PropTypes.shape({
+    gatewayUrl: PropTypes.string.isRequired,
   }).isRequired,
   error: PropTypes.shape({
-    message: PropTypes.string.isRequired,
     cause: PropTypes.shape({ message: PropTypes.string.isRequired }),
+    message: PropTypes.string.isRequired,
+    options: PropTypes.shape({
+      id: PropTypes.string,
+      json: PropTypes.shape({
+        message: PropTypes.string,
+        errors: PropTypes.arrayOf(PropTypes.shape({
+          message: PropTypes.string,
+          parameters: PropTypes.arrayOf(PropTypes.shape({
+            value: PropTypes.string,
+          })),
+        })),
+      }),
+      url: PropTypes.string,
+    }),
   }).isRequired
 };
 

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useIntl } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
@@ -9,8 +9,6 @@ import styles from './index.css';
 
 function FatalError({ branding, config, error }) {
   const intl = useIntl();
-  const [message, setMessage] = useState();
-  const [subMessage, setSubMessage] = useState();
 
   const handleLogout = async () => {
     await fetch(`${config.gatewayUrl}/logout`, {
@@ -24,17 +22,16 @@ function FatalError({ branding, config, error }) {
     location.reload();
   }
 
-  useEffect(() => {
-    if (error?.options?.json) {
-      if (error?.options.json?.errors[0]?.message) {
-        setMessage(error.options.json?.errors[0]?.message);
-        const params = error.options.json.errors[0]?.parameters;
-        if (params && params[0]?.value) {
-          setSubMessage(params[0].value);
-        }
-      }
+  let message = null;
+  let subMessage = null;
+  const errors = error?.options?.json?.errors;
+  if (errors && errors[0]?.message) {
+    setMessage(errors[0]?.message);
+    const params = errors[0]?.parameters;
+    if (params && params[0]?.value) {
+      setSubMessage(params[0].value);
     }
-  }, [error]);
+  }
 
   return (
     <main style={{ width: '100%' }}>
@@ -47,7 +44,7 @@ function FatalError({ branding, config, error }) {
           </Row>
           <Row center="xs">
             <Col xs={12}>
-              <h1>Rats. You successfully signed in, but FOLIO failed to load because of an error 😢</h1>
+              <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
               <h2>{error.message}</h2>
               <h3>{message}</h3>
               <h3>{subMessage}</h3>
@@ -59,7 +56,7 @@ function FatalError({ branding, config, error }) {
                 className={styles.submitButton}
                 onClick={handleReload}
               >
-                Try again
+                <FormattedMessage id="stripes-hub.FatalError.tryAgain" />
               </Button>
             </Col>
             <Col xs={6}>
@@ -67,7 +64,7 @@ function FatalError({ branding, config, error }) {
                 className={styles.submitButton}
                 onClick={handleLogout}
               >
-                Logout
+                <FormattedMessage id="stripes-hub.FatalError.logout" />
               </Button>
             </Col>
           </Row>

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -24,15 +24,17 @@ function FatalError({ branding, config, error }) {
     location.reload();
   }
 
-  if (error?.options?.json) {
-    if (error?.options.json?.errors[0]?.message) {
-      setMessage(error.options.json?.errors[0]?.message);
-      const params = error.options.json.errors[0]?.parameters;
-      if (params && params[0]?.value) {
-        setSubMessage(params[0].value);
+  useEffect(() => {
+    if (error?.options?.json) {
+      if (error?.options.json?.errors[0]?.message) {
+        setMessage(error.options.json?.errors[0]?.message);
+        const params = error.options.json.errors[0]?.parameters;
+        if (params && params[0]?.value) {
+          setSubMessage(params[0].value);
+        }
       }
     }
-  }
+  }, [error]);
 
   return (
     <main style={{ width: '100%' }}>

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -1,4 +1,3 @@
-import React, { useEffect, useState } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
@@ -10,6 +9,7 @@ import styles from './index.css';
 function FatalError({ branding, config, error }) {
   const intl = useIntl();
 
+  console.error({ error })
   const handleLogout = async () => {
     await fetch(`${config.gatewayUrl}/logout`, {
       method: 'POST',
@@ -22,23 +22,28 @@ function FatalError({ branding, config, error }) {
     location.reload();
   }
 
+  // did we get some juicy json in an API response?
   let message = null;
   let subMessage = null;
   const errors = error?.options?.json?.errors;
   if (errors && errors[0]?.message) {
-    setMessage(errors[0]?.message);
+    message = errors[0]?.message;
     const params = errors[0]?.parameters;
     if (params && params[0]?.value) {
-      setSubMessage(params[0].value);
+      subMessage = params[0].value;
     }
+  } else if (error?.options?.json?.message) {
+    message = error?.options?.json?.message;
   }
+
+  const l10nMessage = error.options?.id ? intl.formatMessage({ id: error.options.id }, { url: error?.options?.url }) : error.message;
 
   return (
     <Template branding={branding}>
       <Row center="xs">
         <Col xs={12}>
           <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
-          <h2>{error.message}</h2>
+          <h2>{l10nMessage}</h2>
           <h3>{message}</h3>
           <h3>{subMessage}</h3>
         </Col>

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -3,7 +3,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
-import { getLoginUrl, getCurrentTenant } from './loginServices';
+import Template from './Template';
 import styles from './index.css';
 
 
@@ -34,43 +34,35 @@ function FatalError({ branding, config, error }) {
   }
 
   return (
-    <main style={{ width: '100%' }}>
-      <div>
-        <div className={styles.container}>
-          <Row center="xs">
-            <Col xs={12}>
-              <OrganizationLogo branding={branding} />
-            </Col>
-          </Row>
-          <Row center="xs">
-            <Col xs={12}>
-              <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
-              <h2>{error.message}</h2>
-              <h3>{message}</h3>
-              <h3>{subMessage}</h3>
-            </Col>
-          </Row>
-          <Row center="xs">
-            <Col xs={6}>
-              <Button
-                className={styles.submitButton}
-                onClick={handleReload}
-              >
-                <FormattedMessage id="stripes-hub.FatalError.tryAgain" />
-              </Button>
-            </Col>
-            <Col xs={6}>
-              <Button
-                className={styles.submitButton}
-                onClick={handleLogout}
-              >
-                <FormattedMessage id="stripes-hub.FatalError.logout" />
-              </Button>
-            </Col>
-          </Row>
-        </div>
-      </div>
-    </main>
+    <Template branding={branding}>
+      <Row center="xs">
+        <Col xs={12}>
+          <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
+          <h2>{error.message}</h2>
+          <h3>{message}</h3>
+          <h3>{subMessage}</h3>
+        </Col>
+      </Row>
+      <Row center="xs">
+        <Col xs={6}>
+          <Button
+            className={styles.submitButton}
+            onClick={handleReload}
+          >
+            <FormattedMessage id="stripes-hub.FatalError.tryAgain" />
+          </Button>
+        </Col>
+        <Col xs={6}>
+          <Button
+            className={styles.submitButton}
+            onClick={handleLogout}
+          >
+            <FormattedMessage id="stripes-hub.FatalError.logout" />
+          </Button>
+        </Col>
+      </Row>
+    </Template>
+
   );
 }
 

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { Button, Col, Row } from './StripesComponents';
 import StripesTemplate from './StripesTemplate';
 import styles from './index.css';
-import { config } from 'localforage';
-
 
 function FatalError({ branding, config, error }) {
   const intl = useIntl();

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -13,6 +13,7 @@ import {
 
 import useExchangeCode from './hooks/useExchangeCode';
 import FatalError from './FatalError';
+import Template from './Template';
 
 /**
  * OidcLanding: un-authenticated route handler for /oidc-landing.
@@ -49,6 +50,7 @@ const OidcLanding = ({ branding, config }) => {
           return storeCurrentTenant(loginTenant.name, loginTenant.clientId);
         })
         .then(() => {
+          // TODO: ruwp makes a duplicate API call to _self; how can we avoid this
           return requestUserWithPerms(config, loginTenant.name);
         }).then(() => {
           // upon successful session init, redirect to root for stripes-core to proceed with normal boot.
@@ -67,12 +69,14 @@ const OidcLanding = ({ branding, config }) => {
   }
 
   return (
-    <div data-test-saml-success>
-      <div>
-        {isLoading && <h1><FormattedMessage id="stripes-hub.OidcLanding.validatingAuthenticationToken" /></h1>}
-        {tokenData && <h1><FormattedMessage id="stripes-hub.OidcLanding.initializingSession" /></h1>}
+    <Template branding={branding}>
+      <div data-test-saml-success>
+        <div>
+          {isLoading && <h1><FormattedMessage id="stripes-hub.OidcLanding.validatingAuthenticationToken" /></h1>}
+          {tokenData && <h1><FormattedMessage id="stripes-hub.OidcLanding.initializingSession" /></h1>}
+        </div>
       </div>
-    </div>
+    </Template>
   );
 };
 

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -1,4 +1,4 @@
-import { useIntl, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -47,7 +47,6 @@ const OidcLanding = ({ branding, config }) => {
           return storeCurrentTenant(loginTenant.name, loginTenant.clientId);
         })
         .then(() => {
-          // TODO: ruwp makes a duplicate API call to _self; how can we avoid this
           return requestUserWithPerms(config, loginTenant.name);
         }).then(() => {
           // upon successful session init, redirect to root for stripes-core to proceed with normal boot.

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -8,7 +8,6 @@ import {
   requestUserWithPerms,
   setTokenExpiry,
   storeCurrentTenant,
-  StripesHubError
 } from './loginServices';
 
 import useExchangeCode from './hooks/useExchangeCode';
@@ -27,8 +26,6 @@ import StripesTemplate from './StripesTemplate';
  * @see RootWithIntl
  */
 const OidcLanding = ({ branding, config }) => {
-  const intl = useIntl();
-
   const atDefaultExpiration = Date.now() + (60 * 1000);
   const rtDefaultExpiration = Date.now() + (2 * 60 * 1000);
 
@@ -81,10 +78,19 @@ const OidcLanding = ({ branding, config }) => {
 };
 
 OidcLanding.propTypes = {
+  branding: PropTypes.shape({
+    favicon: PropTypes.shape({
+      src: PropTypes.string,
+    }),
+    logo: PropTypes.shape({
+      alt: PropTypes.string,
+      src: PropTypes.string,
+    }),
+  }),
   config: PropTypes.shape({
-    gatewayUrl: PropTypes.string.isRequired,
     authnUrl: PropTypes.string.isRequired,
     discoveryUrl: PropTypes.string,
+    gatewayUrl: PropTypes.string.isRequired,
   }).isRequired
 };
 

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -13,7 +13,7 @@ import {
 
 import useExchangeCode from './hooks/useExchangeCode';
 import FatalError from './FatalError';
-import Template from './Template';
+import StripesTemplate from './StripesTemplate';
 
 /**
  * OidcLanding: un-authenticated route handler for /oidc-landing.
@@ -69,14 +69,14 @@ const OidcLanding = ({ branding, config }) => {
   }
 
   return (
-    <Template branding={branding}>
+    <StripesTemplate branding={branding}>
       <div data-test-saml-success>
         <div>
           {isLoading && <h1><FormattedMessage id="stripes-hub.OidcLanding.validatingAuthenticationToken" /></h1>}
           {tokenData && <h1><FormattedMessage id="stripes-hub.OidcLanding.initializingSession" /></h1>}
         </div>
       </div>
-    </Template>
+    </StripesTemplate>
   );
 };
 

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -1,4 +1,4 @@
-import { useIntl } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -8,9 +8,11 @@ import {
   requestUserWithPerms,
   setTokenExpiry,
   storeCurrentTenant,
+  StripesHubError
 } from './loginServices';
 
 import useExchangeCode from './hooks/useExchangeCode';
+import FatalError from './FatalError';
 
 /**
  * OidcLanding: un-authenticated route handler for /oidc-landing.
@@ -23,7 +25,7 @@ import useExchangeCode from './hooks/useExchangeCode';
  *
  * @see RootWithIntl
  */
-const OidcLanding = ({ config }) => {
+const OidcLanding = ({ branding, config }) => {
   const intl = useIntl();
 
   const atDefaultExpiration = Date.now() + (60 * 1000);
@@ -58,13 +60,17 @@ const OidcLanding = ({ config }) => {
     }
   };
 
-  const { tokenData, isLoading } = useExchangeCode(config, initSession);
+  const { error, isLoading, tokenData } = useExchangeCode(config, initSession);
+
+  if (error) {
+    return <FatalError branding={branding} config={config} error={error} />;
+  }
 
   return (
     <div data-test-saml-success>
       <div>
-        {isLoading && intl.formatMessage({ id: 'stripes-core.oidc.validatingAuthenticationToken' })}
-        {tokenData && intl.formatMessage({ id: 'stripes-core.oidc.initializingSession' })}
+        {isLoading && <h1><FormattedMessage id="stripes-hub.OidcLanding.validatingAuthenticationToken" /></h1>}
+        {tokenData && <h1><FormattedMessage id="stripes-hub.OidcLanding.initializingSession" /></h1>}
       </div>
     </div>
   );

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -17,7 +17,7 @@ export function sortedTenantOptions(tenantOptions) {
     .map(i => ({ value: i.name, label: i.displayName ?? i.name }));
 }
 
-function PreLoginLanding({ config, branding, onSelectTenant, tenantOptions }) {
+function PreLoginLanding({ branding, config, onSelectTenant, tenantOptions }) {
   const intl = useIntl();
 
   const options = sortedTenantOptions(tenantOptions);
@@ -82,6 +82,7 @@ PreLoginLanding.propTypes = {
     authnUrl: PropTypes.string.isRequired,
   }).isRequired,
   onSelectTenant: PropTypes.func.isRequired,
+  tenantOptions: PropTypes.object.isRequired,
 };
 
 export default PreLoginLanding;

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
+import { Button, Col, Row, Select } from './StripesComponents';
 import { getLoginUrl, getCurrentTenant } from './loginServices';
 import styles from './index.css';
 import StripesTemplate from './StripesTemplate';
@@ -17,7 +17,7 @@ export function sortedTenantOptions(tenantOptions) {
     .map(i => ({ value: i.name, label: i.displayName ?? i.name }));
 }
 
-function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
+function PreLoginLanding({ config, branding, onSelectTenant, tenantOptions }) {
   const intl = useIntl();
 
   const options = sortedTenantOptions(tenantOptions);
@@ -69,6 +69,18 @@ function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
 }
 
 PreLoginLanding.propTypes = {
+  branding: PropTypes.shape({
+    favicon: PropTypes.shape({
+      src: PropTypes.string,
+    }),
+    logo: PropTypes.shape({
+      alt: PropTypes.string,
+      src: PropTypes.string,
+    }),
+  }),
+  config: PropTypes.shape({
+    authnUrl: PropTypes.string.isRequired,
+  }).isRequired,
   onSelectTenant: PropTypes.func.isRequired,
 };
 

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
 import { getLoginUrl, getCurrentTenant } from './loginServices';
 import styles from './index.css';
+import Template from './Template';
 
 export function sortedTenantOptions(tenantOptions) {
   return Object.values(tenantOptions)
@@ -45,34 +46,25 @@ function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
   };
 
   return (
-    <main style={{ width: '100%' }}>
-      <div>
-        <div className={styles.container}>
-          <Row center="xs">
-            <Col xs={6}>
-              <OrganizationLogo branding={branding} />
-            </Col>
-          </Row>
-          <Row center="xs">
-            <Col xs={3}>
-              <Select
-                label={intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantLibrary' })}
-                defaultValue=""
-                onChange={handleChangeTenant}
-                dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantChoose' }) }]}
-              />
-              <Button
-                className={styles.submitButton}
-                disabled={isButtonDisabled}
-                onClick={redirectToLogin}
-              >
-                {intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.button.continue' })}
-              </Button>
-            </Col>
-          </Row>
-        </div>
-      </div>
-    </main>
+    <Template branding={branding}>
+      <Row center="xs">
+        <Col xs={3}>
+          <Select
+            label={intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantLibrary' })}
+            defaultValue=""
+            onChange={handleChangeTenant}
+            dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantChoose' }) }]}
+          />
+          <Button
+            className={styles.submitButton}
+            disabled={isButtonDisabled}
+            onClick={redirectToLogin}
+          >
+            {intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.button.continue' })}
+          </Button>
+        </Col>
+      </Row>
+    </Template>
   );
 }
 

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Button, Col, OrganizationLogo, Row, Select } from './StripesComponents';
 import { getLoginUrl, getCurrentTenant } from './loginServices';
 import styles from './index.css';
-import Template from './Template';
+import StripesTemplate from './StripesTemplate';
 
 export function sortedTenantOptions(tenantOptions) {
   return Object.values(tenantOptions)
@@ -46,7 +46,7 @@ function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
   };
 
   return (
-    <Template branding={branding}>
+    <StripesTemplate branding={branding}>
       <Row center="xs">
         <Col xs={3}>
           <Select
@@ -64,7 +64,7 @@ function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
           </Button>
         </Col>
       </Row>
-    </Template>
+    </StripesTemplate>
   );
 }
 

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -18,7 +18,7 @@ export function sortedTenantOptions(tenantOptions) {
 
 function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
   const intl = useIntl();
-  
+
   const options = sortedTenantOptions(tenantOptions);
 
   const redirectToLogin = () => {
@@ -56,19 +56,17 @@ function PreLoginLanding({ onSelectTenant, config, branding, tenantOptions }) {
           <Row center="xs">
             <Col xs={3}>
               <Select
-                label={intl.formatMessage({ id: 'stripes-core.tenantLibrary' })}
+                label={intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantLibrary' })}
                 defaultValue=""
                 onChange={handleChangeTenant}
-                dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-core.tenantChoose' }) }]}
+                dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantChoose' }) }]}
               />
               <Button
-                buttonClass={styles.submitButton}
+                className={styles.submitButton}
                 disabled={isButtonDisabled}
                 onClick={redirectToLogin}
-                buttonStyle="primary"
-                fullWidth
               >
-                {intl.formatMessage({ id: 'stripes-core.button.continue' })}
+                {intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.button.continue' })}
               </Button>
             </Col>
           </Row>

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useIntl, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -4,13 +4,10 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
 import FatalError from './FatalError';
-import { Col, OrganizationLogo, Row } from './StripesComponents';
+import { Col, Row } from './StripesComponents';
 import StripesTemplate from './StripesTemplate';
-import styles from './index.css';
 
 function StripesHub({ branding, config }) {
-  const intl = useIntl();
-
   const {
     isLoadingDiscovery,
     discoveryError,

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -5,6 +5,7 @@ import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
 import FatalError from './FatalError';
 import { Col, OrganizationLogo, Row } from './StripesComponents';
+import Template from './Template';
 import styles from './index.css';
 
 function StripesHub({ branding, config }) {
@@ -27,27 +28,18 @@ function StripesHub({ branding, config }) {
   }
 
   return (
-    <main style={{ width: '100%' }}>
-      <div>
-        <div className={styles.container}>
-          <Row center="xs">
-            <Col xs={12}>
-              <OrganizationLogo branding={branding} />
-            </Col>
-          </Row>
-          <Row center="xs">
-            <Col xs={12}>
-              <div data-testid="StripesHub">
-                {isLoadingEntitlement && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingEntitlements" /></h1>}
-                {isLoadingDiscovery && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingDiscovery" /></h1>}
-                {isLoadingSession && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingSession" /></h1>}
-                {isLoadingStripes && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingStripes" /></h1>}
-              </div>
-            </Col>
-          </Row>
-        </div>
-      </div>
-    </main>
+    <Template branding={branding}>
+      <Row center="xs">
+        <Col xs={12}>
+          <div data-testid="StripesHub">
+            {isLoadingEntitlement && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingEntitlements" /></h1>}
+            {isLoadingDiscovery && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingDiscovery" /></h1>}
+            {isLoadingSession && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingSession" /></h1>}
+            {isLoadingStripes && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingStripes" /></h1>}
+          </div>
+        </Col>
+      </Row>
+    </Template>
   );
 }
 

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -1,14 +1,22 @@
 import PropTypes from 'prop-types';
+import { useIntl, FormattedMessage } from 'react-intl';
 
 import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
+import FatalError from './FatalError';
 
 function StripesHub({ config, branding }) {
-  const { isLoading } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
+  const intl = useIntl();
+
+  const { error, isLoading } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
+
+  if (error) {
+    return <FatalError branding={branding} config={config} error={error} />;
+  }
 
   return (
     <div data-testid="StripesHub">
-      {isLoading && <h1>Initializing session...</h1>}
+      {isLoading && <h1><FormattedMessage id="stripes-hub.StripesHub.initializingSession" /></h1>}
     </div>
   );
 }

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -4,20 +4,50 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
 import FatalError from './FatalError';
+import { Col, OrganizationLogo, Row } from './StripesComponents';
+import styles from './index.css';
 
-function StripesHub({ config, branding }) {
+function StripesHub({ branding, config }) {
   const intl = useIntl();
 
-  const { error, isLoading } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
+  const {
+    isLoadingDiscovery,
+    discoveryError,
+    isLoadingEntitlement,
+    entitlementError,
+    isLoadingStripes,
+    stripesError,
+    isLoadingSession,
+    sessionError,
+  } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
 
-  if (error) {
+  if (discoveryError || entitlementError || stripesError || sessionError) {
+    const error = discoveryError || entitlementError || stripesError || sessionError;
     return <FatalError branding={branding} config={config} error={error} />;
   }
 
   return (
-    <div data-testid="StripesHub">
-      {isLoading && <h1><FormattedMessage id="stripes-hub.StripesHub.initializingSession" /></h1>}
-    </div>
+    <main style={{ width: '100%' }}>
+      <div>
+        <div className={styles.container}>
+          <Row center="xs">
+            <Col xs={12}>
+              <OrganizationLogo branding={branding} />
+            </Col>
+          </Row>
+          <Row center="xs">
+            <Col xs={12}>
+              <div data-testid="StripesHub">
+                {isLoadingEntitlement && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingEntitlements" /></h1>}
+                {isLoadingDiscovery && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingDiscovery" /></h1>}
+                {isLoadingSession && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingSession" /></h1>}
+                {isLoadingStripes && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingStripes" /></h1>}
+              </div>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </main>
   );
 }
 

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -5,7 +5,7 @@ import useInitSession from './hooks/useInitSession';
 import { urlPaths } from './constants';
 import FatalError from './FatalError';
 import { Col, OrganizationLogo, Row } from './StripesComponents';
-import Template from './Template';
+import StripesTemplate from './StripesTemplate';
 import styles from './index.css';
 
 function StripesHub({ branding, config }) {
@@ -28,7 +28,7 @@ function StripesHub({ branding, config }) {
   }
 
   return (
-    <Template branding={branding}>
+    <StripesTemplate branding={branding}>
       <Row center="xs">
         <Col xs={12}>
           <div data-testid="StripesHub">
@@ -39,7 +39,7 @@ function StripesHub({ branding, config }) {
           </div>
         </Col>
       </Row>
-    </Template>
+    </StripesTemplate>
   );
 }
 

--- a/src/StripesHub.test.js
+++ b/src/StripesHub.test.js
@@ -17,12 +17,22 @@ test('renders', () => {
     preserveConsole: true
   };
 
+  const branding = {
+    logo: {
+      src: 'http://logo',
+      alt: 'logo-alt-text',
+    },
+    favicon: {
+      src: 'http://favicon',
+    },
+  };
+
   const reactQueryClient = createReactQueryClient();
 
   render(
     <QueryClientProvider client={reactQueryClient}>
       <IntlProvider locale="en">
-        <StripesHub config={config} />
+        <StripesHub branding={branding} config={config} />
       </IntlProvider>
     </QueryClientProvider>
   );

--- a/src/StripesTemplate.js
+++ b/src/StripesTemplate.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Col, OrganizationLogo, Row } from './StripesComponents';
 import styles from './index.css';
 
-function Template({ branding, children }) {
+function StripesTemplate({ branding, children }) {
   const intl = useIntl();
 
   return (
@@ -23,7 +23,7 @@ function Template({ branding, children }) {
   );
 }
 
-Template.propTypes = {
+StripesTemplate.propTypes = {
   branding: PropTypes.shape({
     logo: PropTypes.string,
     altText: PropTypes.string,
@@ -31,4 +31,4 @@ Template.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-export default Template;
+export default StripesTemplate;

--- a/src/StripesTemplate.js
+++ b/src/StripesTemplate.js
@@ -1,12 +1,9 @@
-import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { Col, OrganizationLogo, Row } from './StripesComponents';
 import styles from './index.css';
 
 function StripesTemplate({ branding, children }) {
-  const intl = useIntl();
-
   return (
     <main style={{ width: '100%' }}>
       <div>

--- a/src/Template.js
+++ b/src/Template.js
@@ -1,0 +1,34 @@
+import { useIntl, FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
+
+import { Col, OrganizationLogo, Row } from './StripesComponents';
+import styles from './index.css';
+
+function Template({ branding, children }) {
+  const intl = useIntl();
+
+  return (
+    <main style={{ width: '100%' }}>
+      <div>
+        <div className={styles.container}>
+          <Row center="xs">
+            <Col xs={12}>
+              <OrganizationLogo branding={branding} />
+            </Col>
+          </Row>
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+Template.propTypes = {
+  branding: PropTypes.shape({
+    logo: PropTypes.string,
+    altText: PropTypes.string,
+  }).isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default Template;

--- a/src/hooks/useExchangeCode.js
+++ b/src/hooks/useExchangeCode.js
@@ -32,16 +32,14 @@ const useExchangeCode = (config, initSession = noop) => {
             return json;
           }
 
-          throw new StripesHubError(`Token exchange failed`, { json });
+          throw new StripesHubError(`Token exchange failure`, { json, id: 'stripes-hub.error.tokenExchangeFailure ' });
 
         } catch (error) {
-          console.error({ error }); // eslint-disable-line no-console
-          // rethrow if error is already wrapped
-          if (error instanceof StripesHubError) {
-            throw error;
-          }
-
-          throw new StripesHubError('monkeys', { cause: fetchError, message: 'fetch error during OTP exchange' })
+          const json = error?.options?.json || null;
+          throw new StripesHubError(
+            `Token exchange failure`,
+            { json, id: 'stripes-hub.error.tokenExchangeFailure', cause: error }
+          );
         }
       }
 

--- a/src/hooks/useExchangeCode.js
+++ b/src/hooks/useExchangeCode.js
@@ -40,14 +40,8 @@ const useExchangeCode = (config, initSession = noop) => {
           if (error instanceof StripesHubError) {
             throw error;
           }
-          // throw new StripesHubError('monkeys', { cause: fetchError, message: 'fetch error during OTP exchange' })
-          // // throw json from the error-response, or just rethrow
-          // if (fetchError?.response?.json) {
-          //   const errorJson = await fetchError.response.json();
-          //   throw errorJson;
-          // }
 
-          throw fetchError;
+          throw new StripesHubError('monkeys', { cause: fetchError, message: 'fetch error during OTP exchange' })
         }
       }
 

--- a/src/hooks/useExchangeCode.js
+++ b/src/hooks/useExchangeCode.js
@@ -2,9 +2,9 @@ import { useQuery } from 'react-query';
 import { useIntl } from 'react-intl';
 import noop from 'lodash/noop';
 
-import { getLoginTenant, getHeaders } from '../loginServices';
+import { getLoginTenant, getHeaders, StripesHubError } from '../loginServices';
 
-const useExchangeCode = async (config, initSession = noop) => {
+const useExchangeCode = (config, initSession = noop) => {
   const intl = useIntl();
   const urlParams = new URLSearchParams(globalThis.location.search);
   const code = urlParams.get('code');
@@ -26,21 +26,26 @@ const useExchangeCode = async (config, initSession = noop) => {
 
           const json = await response.json();
 
-          // note: initSession is expected to execute an unawaited promise.
-          // initSession calls .../_self and other functions in order to
-          // populate the session, eventually triggering a re-render. so,
-          // even though it's async, we do not await it here, instead
-          // returning the response-json that can be used to show a status
-          // update while session-init is still in-flight.
-          initSession(json);
-
-          return json;
-        } catch (fetchError) {
-          // throw json from the error-response, or just rethrow
-          if (fetchError?.response?.json) {
-            const errorJson = await fetchError.response.json();
-            throw errorJson;
+          if (response.ok) {
+            // initSession eventually redirects to /
+            await initSession(json);
+            return json;
           }
+
+          throw new StripesHubError(`Token exchange failed`, { json });
+
+        } catch (error) {
+          console.error({ error }); // eslint-disable-line no-console
+          // rethrow if error is already wrapped
+          if (error instanceof StripesHubError) {
+            throw error;
+          }
+          // throw new StripesHubError('monkeys', { cause: fetchError, message: 'fetch error during OTP exchange' })
+          // // throw json from the error-response, or just rethrow
+          // if (fetchError?.response?.json) {
+          //   const errorJson = await fetchError.response.json();
+          //   throw errorJson;
+          // }
 
           throw fetchError;
         }

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -9,7 +9,7 @@ import {
   USERS_PATH,
 } from '../loginServices';
 
-const useInitSession = async (config, branding, loginUrl) => {
+const useInitSession = (config, branding, loginUrl) => {
 
   const getSessionTenant = (session) => {
     return session.tenant;
@@ -75,6 +75,8 @@ const useInitSession = async (config, branding, loginUrl) => {
       try {
         const session = await getSession();
 
+        // retrieve session data. if none is available, redirect to login
+        // because we pass `authenticate()` as the error handler
         session?.user?.id ? await validateSession(session, authenticate) : authenticate();
 
         if (session && sessionIsValid(session)) {
@@ -87,7 +89,8 @@ const useInitSession = async (config, branding, loginUrl) => {
           // even though it's async, we do not await it here, instead
           // returning the response-json that can be used to show a status
           // update while session-init is still in-flight.
-          initStripes(config, branding, sessionTenant);
+          const initRes = await initStripes(config, branding, sessionTenant);
+          console.log({ initRes })
 
           return session;
         } else {
@@ -95,7 +98,8 @@ const useInitSession = async (config, branding, loginUrl) => {
         }
       } catch (e) {
         console.error('error during StripesHub init', e); // eslint-disable-line no-console
-        alert(`error during StripesHub init: ${JSON.stringify(e, null, 2)}`); // eslint-disable-line no-alert
+        //alert(`error during StripesHub init: ${JSON.stringify(e, null, 2)}`); // eslint-disable-line no-alert
+        return Promise.reject(e)
       }
     },
     {

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -109,9 +109,6 @@ const useInitSession = (config, branding, loginUrl) => {
         cachedSession?.user?.id ? await validateSession(cachedSession, authenticate) : authenticate();
 
         if (cachedSession && sessionIsValid(cachedSession)) {
-          const tenant = getSessionTenant(cachedSession);
-          const { tenant: sessionTenant = tenant } = cachedSession;
-
           return cachedSession;
         } else {
           authenticate();
@@ -170,7 +167,7 @@ const useInitSession = (config, branding, loginUrl) => {
    * @param {string} tenant
    * @returns {Promise<void>} resolves when stripes is initialized
    */
-  const { isLoading: isLoadingStripes, data: stripes, error: stripesError } = useQuery(
+  const { isLoading: isLoadingStripes, error: stripesError } = useQuery(
     ['@folio/stripes-core', 'stripes'],
     async () => {
       console.log({ session, entitlement, discovery });

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -40,10 +40,6 @@ const REMOTE_LIST_KEY = 'entitlements';
  * @returns
  */
 const useInitSession = (config, branding, loginUrl) => {
-  const getSessionTenant = (session) => {
-    return session.tenant;
-  };
-
   const authenticate = () => {
     // Cache the current path so we can return to it after authenticating.
     if (globalThis.location.pathname !== '/') {

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -9,12 +9,6 @@ import {
   getSession,
   loadStripes,
   setUnauthorizedPathToSession,
-  // DISCOVERY_URL_KEY,
-  // FOLIO_BRANDING_KEY,
-  // FOLIO_CONFIG_KEY,
-  // HOST_APP_NAME,
-  // REMOTE_LIST_KEY,
-  // USERS_PATH,
 } from '../loginServices';
 
 /** name for whatever the entitlement service will call the hub app (stripes, stripes-core, etc.) */
@@ -26,12 +20,13 @@ const FOLIO_CONFIG_KEY = 'folio_config';
 /** name for FOLIO branding file locations to be used by entitled applications (such as stripes-core) */
 const FOLIO_BRANDING_KEY = 'branding_config';
 
-// const keys to-be-ingested by stripes-core
+/** root API path to user session data */
+const USERS_PATH = 'users-keycloak';  // TODO: does this need to be a constant? what about okapi?
+
+// localstorage keys to-be-ingested by stripes-core
 const DISCOVERY_URL_KEY = 'discoveryUrl';
 const HOST_LOCATION_KEY = 'hostLocation';
 const REMOTE_LIST_KEY = 'entitlements';
-const USERS_PATH = 'users-keycloak';
-
 
 /**
  * Pull the session from local storage and validate it by fetching from .../_self.
@@ -45,7 +40,6 @@ const USERS_PATH = 'users-keycloak';
  * @returns
  */
 const useInitSession = (config, branding, loginUrl) => {
-
   const getSessionTenant = (session) => {
     return session.tenant;
   };

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -21,7 +21,7 @@ const FOLIO_CONFIG_KEY = 'folio_config';
 const FOLIO_BRANDING_KEY = 'branding_config';
 
 /** root API path to user session data */
-const USERS_PATH = 'users-keycloak';  // TODO: does this need to be a constant? what about okapi?
+const USERS_PATH = 'users-keycloak';
 
 // localstorage keys to-be-ingested by stripes-core
 const DISCOVERY_URL_KEY = 'discoveryUrl';
@@ -142,21 +142,15 @@ const useInitSession = (config, branding, loginUrl) => {
   const { isLoading: isLoadingDiscovery, data: discovery, error: discoveryError } = useQuery(
     ['@folio/stripes-core', 'discovery'],
     async () => {
-      try {
-        const tenant = getCurrentTenant().name;
-        const discovery = await fetchDiscovery(config, tenant, entitlement);
-        return discovery;
-      } catch (error) {
-        throw error;
-      }
+      const tenant = getCurrentTenant().name;
+      const discovery = await fetchDiscovery(config, tenant, entitlement);
+      return discovery;
     },
     {
       retry: false,
       enabled: !!entitlement && Object.keys(entitlement).length > 0, // discovery depends on entitlement, so don't run until we have entitlement data
     }
   );
-
-
 
   /**
    * initStripes

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -142,9 +142,13 @@ const useInitSession = (config, branding, loginUrl) => {
   const { isLoading: isLoadingDiscovery, data: discovery, error: discoveryError } = useQuery(
     ['@folio/stripes-core', 'discovery'],
     async () => {
-      const tenant = getCurrentTenant().name;
-      const discovery = await fetchDiscovery(config, tenant, entitlement);
-      return discovery;
+      try {
+        const tenant = getCurrentTenant().name;
+        const discovery = await fetchDiscovery(config, tenant, entitlement);
+        return discovery;
+      } catch (error) {
+        throw error;
+      }
     },
     {
       retry: false,

--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -1,14 +1,49 @@
 import { useQuery } from 'react-query';
+import localforage from 'localforage';
 
 import {
+  fetchDiscovery,
+  fetchEntitlements,
   getCurrentTenant,
   getHeaders,
   getSession,
-  initStripes,
+  loadStripes,
   setUnauthorizedPathToSession,
-  USERS_PATH,
+  // DISCOVERY_URL_KEY,
+  // FOLIO_BRANDING_KEY,
+  // FOLIO_CONFIG_KEY,
+  // HOST_APP_NAME,
+  // REMOTE_LIST_KEY,
+  // USERS_PATH,
 } from '../loginServices';
 
+/** name for whatever the entitlement service will call the hub app (stripes, stripes-core, etc.) */
+const HOST_APP_NAME = 'folio_stripes';
+
+/** name for FOLIO config stored in localforage to be used by entitled applications (such as stripes-core) */
+const FOLIO_CONFIG_KEY = 'folio_config';
+
+/** name for FOLIO branding file locations to be used by entitled applications (such as stripes-core) */
+const FOLIO_BRANDING_KEY = 'branding_config';
+
+// const keys to-be-ingested by stripes-core
+const DISCOVERY_URL_KEY = 'discoveryUrl';
+const HOST_LOCATION_KEY = 'hostLocation';
+const REMOTE_LIST_KEY = 'entitlements';
+const USERS_PATH = 'users-keycloak';
+
+
+/**
+ * Pull the session from local storage and validate it by fetching from .../_self.
+ * If the session is valid, fetch entitlements and discovery data,
+ * then initialize stripes.
+ *
+ * If the session is invalid at any point in that process, redirect to login.
+ * @param {*} config
+ * @param {*} branding
+ * @param {*} loginUrl
+ * @returns
+ */
 const useInitSession = (config, branding, loginUrl) => {
 
   const getSessionTenant = (session) => {
@@ -69,37 +104,27 @@ const useInitSession = (config, branding, loginUrl) => {
     }
   };
 
-  const { isFetching, data, error } = useQuery(
+  const { isLoading: isLoadingSession, data: session, error: sessionError } = useQuery(
     ['@folio/stripes-core', 'initSession'],
     async () => {
       try {
-        const session = await getSession();
+        const cachedSession = await getSession();
 
         // retrieve session data. if none is available, redirect to login
         // because we pass `authenticate()` as the error handler
-        session?.user?.id ? await validateSession(session, authenticate) : authenticate();
+        cachedSession?.user?.id ? await validateSession(cachedSession, authenticate) : authenticate();
 
-        if (session && sessionIsValid(session)) {
-          const tenant = getSessionTenant(session);
-          const { tenant: sessionTenant = tenant } = session;
+        if (cachedSession && sessionIsValid(cachedSession)) {
+          const tenant = getSessionTenant(cachedSession);
+          const { tenant: sessionTenant = tenant } = cachedSession;
 
-          // note: initSession is expected to execute an unawaited promise.
-          // initSession calls .../_self and other functions in order to
-          // populate the session, eventually triggering a re-render. so,
-          // even though it's async, we do not await it here, instead
-          // returning the response-json that can be used to show a status
-          // update while session-init is still in-flight.
-          const initRes = await initStripes(config, branding, sessionTenant);
-          console.log({ initRes })
-
-          return session;
+          return cachedSession;
         } else {
           authenticate();
         }
       } catch (e) {
         console.error('error during StripesHub init', e); // eslint-disable-line no-console
-        //alert(`error during StripesHub init: ${JSON.stringify(e, null, 2)}`); // eslint-disable-line no-alert
-        return Promise.reject(e)
+        throw new Error('Session init error')
       }
     },
     {
@@ -107,10 +132,90 @@ const useInitSession = (config, branding, loginUrl) => {
     }
   );
 
+  const { isLoading: isLoadingEntitlement, data: entitlement, error: entitlementError } = useQuery(
+    ['@folio/stripes-core', 'entitlement'],
+    async () => {
+      const tenant = getCurrentTenant().name;
+      const entitlement = await fetchEntitlements(config, tenant);
+      return entitlement;
+    },
+    {
+      retry: false,
+      enabled: !!session,
+    }
+  );
+
+  const { isLoading: isLoadingDiscovery, data: discovery, error: discoveryError } = useQuery(
+    ['@folio/stripes-core', 'discovery'],
+    async () => {
+      const tenant = getCurrentTenant().name;
+      const discovery = await fetchDiscovery(config, tenant, entitlement);
+      return discovery;
+    },
+    {
+      retry: false,
+      enabled: !!entitlement && Object.keys(entitlement).length > 0, // discovery depends on entitlement, so don't run until we have entitlement data
+    }
+  );
+
+
+
+  /**
+   * initStripes
+   * Fetch entitlements and discovery data, then cache it in local storage.
+   * Pluck stripes from the discovery data and purge it from the cache (we don't
+   * want stripes to try to load itself) and then load stripes.
+   *
+   * Stripes is keyed by folio_stripes-core in the entitlement data, which is
+   * composed of Application Descriptors, themselves composed of Module
+   * Descriptors. IOW, entitlement data only contains modules that have MDs.
+   * Since Stripes itself does not contain an MD but stripes-core does, we take
+   * advantage of that fact, using the folio_stripes-core key in entitlement and
+   * discovery data to find stripes' location.
+   *
+   * @param {object} config
+   * @param {object} branding
+   * @param {string} tenant
+   * @returns {Promise<void>} resolves when stripes is initialized
+   */
+  const { isLoading: isLoadingStripes, data: stripes, error: stripesError } = useQuery(
+    ['@folio/stripes-core', 'stripes'],
+    async () => {
+      console.log({ session, entitlement, discovery });
+      const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
+      if (stripesCore) {
+        await localforage.setItem(DISCOVERY_URL_KEY, config.discoveryUrl ?? config.gatewayUrl);
+        await localforage.setItem(HOST_APP_NAME, HOST_APP_NAME);
+        await localforage.setItem(FOLIO_CONFIG_KEY, config);
+        await localforage.setItem(FOLIO_BRANDING_KEY, branding);
+        await localforage.setItem(HOST_LOCATION_KEY, stripesCore.location);
+
+        // REMOTE_LIST_KEY stores the list of apps that stripes will load,
+        // so we have to remove stripes from that list. Otherwise, Malkovich.
+        // Malkovich Malkovich Malkovich? Malkovich!
+        await localforage.setItem(REMOTE_LIST_KEY, Object.values(discovery).filter(module => module.name !== 'folio_stripes-core'));
+
+        await loadStripes(stripesCore);
+        return Promise.resolve(true);
+      }
+
+      throw new Error('Stripes core module not found in discovery data');
+    },
+    {
+      retry: false,
+      enabled: !!session && !!entitlement && !!discovery, // stripes init depends on session, entitlement, and discovery, so don't run until we have all of that data
+    }
+  );
+
   return ({
-    sessionData: data,
-    isLoading: isFetching,
-    error,
+    isLoadingDiscovery,
+    discoveryError,
+    isLoadingEntitlement,
+    entitlementError,
+    isLoadingStripes,
+    stripesError,
+    isLoadingSession,
+    sessionError,
   });
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import AuthnLogin from './AuthnLogin';
 import StripesHub from './StripesHub';
 import OidcLanding from './OidcLanding';
 import { urlPaths } from './constants';
+import rawTranslations from './translations/stripes-hub/en_US.json';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 const config = FOLIO_CONFIG || {}; // eslint-disable-line no-undef
@@ -19,6 +20,10 @@ const StripesHubComponent = () => <StripesHub config={config} branding={branding
 const reactQueryClient = createReactQueryClient();
 const pathName = globalThis.location.pathname;
 let LandingComponent = StripesHubComponent;
+const translations = Object.keys(rawTranslations).reduce((acc, key) => {
+  acc[`stripes-hub.${key}`] = rawTranslations[key];
+  return acc;
+}, {});
 
 switch (pathName) {
   case urlPaths.AUTHN_LOGIN:
@@ -35,7 +40,7 @@ switch (pathName) {
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={reactQueryClient}>
-      <IntlProvider locale={navigator.language || 'en-US'}>
+      <IntlProvider locale={navigator.language || 'en-US'} messages={translations} >
         <LandingComponent />
       </IntlProvider>
     </QueryClientProvider>

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 const config = FOLIO_CONFIG || {}; // eslint-disable-line no-undef
 const branding = BRANDING_GLOBAL || {}; // eslint-disable-line no-undef
 const AuthnLoginComponent = () => <AuthnLogin config={config} branding={branding} />;
-const OidcLandingComponent = () => <OidcLanding config={config} />;
+const OidcLandingComponent = () => <OidcLanding config={config} branding={branding} />;
 const StripesHubComponent = () => <StripesHub config={config} branding={branding} />;
 
 const reactQueryClient = createReactQueryClient();

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ switch (pathName) {
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={reactQueryClient}>
-      <IntlProvider locale={navigator.language || 'en-US'} messages={translations} >
+      <IntlProvider locale={config.locale || navigator.language || 'en-US'} messages={translations} >
         <LandingComponent />
       </IntlProvider>
     </QueryClientProvider>

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -187,7 +187,7 @@ const ffetch = async (url, tenant) => {
   // or should the caller trap and rethrow with more context? e.g. "entitlement error", "discovery error"?
   if (!res.ok) {
     const json = await res.json();
-    throw new StripesHubError(`Fetch to ${url} failed: ${res.status} ${res.statusText}`, { json });
+    throw new StripesHubError(`Fetch to ${url} failed: ${res.status} ${res.statusText}`, { json, url });
   }
 
   const json = await res.json();
@@ -291,15 +291,17 @@ const fetchCustomDiscovery = async (config, tenant, entitlement) => {
  * @returns {Promise<object>} map of entitlement and discovery data, keyed by module ID
  */
 const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
+  const url = `${config.gatewayUrl}/applications/${appId}/discovery?limit=500`;
   try {
     const map = {};
 
     const applicationIds = Array.from(new Set(Object.values(entitlement).map(mod => mod.applicationId)));
 
     for (const appId of applicationIds) {
-      const json = await ffetch(`${config.gatewayUrl}/applications/${appId}/discovery?limit=500`, tenant);
+      const json = await ffetch(url, tenant);
       json.discovery.forEach(entry => {
         if (entitlement[entry.id]) {
+          // TODO: use a categorical logger for this or omit it
           console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
           map[entry.id] = entitlement[entry.id];
           map[entry.id].location = entry.location;
@@ -357,50 +359,56 @@ export const fetchDiscovery = async (config, tenant, entitlement) => {
  * Stripes will bootstrap itself once its JS is loaded.
  */
 export const loadStripes = async (stripesCore) => {
+  const url = `${stripesCore.location}/manifest.json`;
   try {
-    console.log('x')
-    const manifestJSON = await fetch(`${stripesCore.location}/manifest.json`);
-    if (!manifestJSON.ok) {
-      throw new Error(`Failed to fetch manifest: ${stripesCore.location}/manifest.json`);
-    }
+    const manifestJSON = await fetch(url);
     const manifest = await manifestJSON.json();
 
-    // collect imports...
-    const jsImports = new Set();
-    const cssImports = new Set();
-    Object.keys(manifest.entrypoints).forEach((entry) => {
-      manifest.entrypoints[entry].imports.forEach((imp) => {
-        if (imp.endsWith('.js')) {
-          jsImports.add(imp);
-        } else if (imp.endsWith('.css')) {
-          cssImports.add(imp);
-        }
+    if (manifestJSON.ok) {
+      // collect imports...
+      const jsImports = new Set();
+      const cssImports = new Set();
+      Object.keys(manifest.entrypoints).forEach((entry) => {
+        manifest.entrypoints[entry].imports.forEach((imp) => {
+          if (imp.endsWith('.js')) {
+            jsImports.add(imp);
+          } else if (imp.endsWith('.css')) {
+            cssImports.add(imp);
+          }
+        });
       });
-    });
 
-    cssImports.forEach((cssRef) => {
-      const cssFile = manifest.assets[cssRef].file
-      const link = document.createElement('link');
-      link.rel = 'stylesheet';
-      link.href = `${stripesCore.location}${cssFile}`;
-      document.head.appendChild(link);
-    });
+      cssImports.forEach((cssRef) => {
+        const cssFile = manifest.assets[cssRef].file
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = `${stripesCore.location}${cssFile}`;
+        document.head.appendChild(link);
+      });
 
-    for (const jsRef of jsImports) {
-      const jsFile = manifest.assets[jsRef].file;
-      console.log(`Loading stripes asset ${stripesCore.location}${jsFile}...`)
-      await import(/* webpackIgnore: true */ `${stripesCore.location}${jsFile}`);
+      for (const jsRef of jsImports) {
+        const jsFile = manifest.assets[jsRef].file;
+        console.log(`Loading stripes asset ${stripesCore.location}${jsFile}...`)
+        await import(/* webpackIgnore: true */ `${stripesCore.location}${jsFile}`);
+      }
+      return;
     }
+
+    throw new Error('Failed to fetch manifest', { json: manifest });
+
   } catch (error) {
-    console.log('ccccccccc')
-    console.error('error loading stripes', error.message); // eslint-disable-line no-console
-    throw error;
+    console.error(error); // eslint-disable-line no-console
+    const json = error?.options?.json || null;
+    throw new StripesHubError(
+      `Stripes init error at ${url}`,
+      { json, url, id: 'stripes-hub.error.stripesFetchFailure', cause: error }
+    );
   }
 }
 
 /**
  * spreadUserWithPerms
- * Restructure the response from `bl-users/self?expandPermissions=true`
+ * Restructure the response from `bl - users / self ? expandPermissions = true`
  * to return an object shaped like
  * {
  *   user: { id, username, ...personal }

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -183,9 +183,11 @@ const ffetch = async (url, tenant) => {
     mode: 'cors',
   });
 
+  // TODO: should ffetch be responsible for throwing this generic error
+  // or should the caller trap and rethrow with more context? e.g. "entitlement error", "discovery error"?
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Fetch to ${url} failed: ${res.status} ${res.statusText} - ${text}`);
+    const json = await res.json();
+    throw new StripesHubError(`Fetch to ${url} failed: ${res.status} ${res.statusText}`, { json });
   }
 
   const json = await res.json();
@@ -201,27 +203,36 @@ const ffetch = async (url, tenant) => {
  * @returns {Promise<map>} map of entitlement data, keyed by module ID
  */
 export const fetchEntitlements = async (config, tenant) => {
-  const entitlement = {};
-  const json = await ffetch(`${config.gatewayUrl}/entitlements/${tenant}/applications`, tenant);
-  const elist = json.applicationDescriptors;
-  elist.forEach(application => {
-    application.uiModules.forEach(module => {
-      entitlement[module.id] = module;
+  const url = `${config.gatewayUrl}/entitlements/${tenant}/applications`;
+  try {
+    const entitlement = {};
+    const json = await ffetch(url, tenant);
+    const elist = json.applicationDescriptors;
+    elist.forEach(application => {
+      application.uiModules.forEach(module => {
+        entitlement[module.id] = module;
 
-      // store application IDs for use in the dicovery API query
-      entitlement[module.id].applicationId = application.id;
+        // store application IDs for use in the dicovery API query
+        entitlement[module.id].applicationId = application.id;
+      });
+      application.uiModuleDescriptors.forEach(module => {
+        if (entitlement[module.id]) {
+          entitlement[module.id].okapiInterfaces = module.requires;
+          entitlement[module.id].optionalOkapiInterfaces = module.optional;
+          entitlement[module.id] = { ...entitlement[module.id], ...module.metadata?.stripes };
+        }
+      });
     });
-    application.uiModuleDescriptors.forEach(module => {
-      if (entitlement[module.id]) {
 
-        entitlement[module.id].okapiInterfaces = module.requires;
-        entitlement[module.id].optionalOkapiInterfaces = module.optional;
-        entitlement[module.id] = { ...entitlement[module.id], ...module.metadata?.stripes };
-      }
-    });
-  });
+    return entitlement;
+  } catch (error) {
+    const json = error?.options?.json || null;
 
-  return entitlement;
+    throw new StripesHubError(
+      `Entitlement fetch error at ${url}`,
+      { json, url, id: 'stripes-hub.error.entitlementFetch', cause: error }
+    );
+  }
 };
 
 /**
@@ -240,26 +251,32 @@ export const fetchEntitlements = async (config, tenant) => {
 const fetchCustomDiscovery = async (config, tenant, entitlement) => {
   const map = {};
 
-  // const json = await ffetch(`${config.discoveryUrl}`, tenant);
   const res = await fetch(`${config.discoveryUrl}`, {
     headers: getHeaders(tenant),
-    // credentials: 'include',
     mode: 'cors',
   });
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Fetch to ${url} failed: ${res.status} ${res.statusText} - ${text}`);
+  if (res.ok) {
+    const json = await res.json();
+
+    json.discovery.forEach(entry => {
+      console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
+      map[entry.id] = entry;
+    });
+
+    return map;
   }
 
-  const json = await res.json();
+  // who knows what kind of errors custom discover might return
+  let json = null;
+  if (res.headers.get('Content-Type')?.includes('application/json')) {
+    json = await res.json();
+  }
 
-  json.discovery.forEach(entry => {
-    console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
-    map[entry.id] = entry;
-  });
-
-  return map;
+  throw new StripesHubError(
+    `Discovery fetch error at ${config.discoveryUrl}`,
+    { json, url: config.discoveryUrl, id: 'stripes-hub.error.discoveryFetch' }
+  );
 };
 
 /**
@@ -274,22 +291,32 @@ const fetchCustomDiscovery = async (config, tenant, entitlement) => {
  * @returns {Promise<object>} map of entitlement and discovery data, keyed by module ID
  */
 const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
-  const map = {};
+  try {
+    const map = {};
 
-  const applicationIds = Array.from(new Set(Object.values(entitlement).map(mod => mod.applicationId)));
+    const applicationIds = Array.from(new Set(Object.values(entitlement).map(mod => mod.applicationId)));
 
-  for (const appId of applicationIds) {
-    const json = await ffetch(`${config.gatewayUrl}/applications/${appId}/discovery?limit=500`, tenant);
-    json.discovery.forEach(entry => {
-      if (entitlement[entry.id]) {
-        console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
-        map[entry.id] = entitlement[entry.id];
-        map[entry.id].location = entry.location;
-      }
-    });
+    for (const appId of applicationIds) {
+      const json = await ffetch(`${config.gatewayUrl}/applications/${appId}/discovery?limit=500`, tenant);
+      json.discovery.forEach(entry => {
+        if (entitlement[entry.id]) {
+          console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
+          map[entry.id] = entitlement[entry.id];
+          map[entry.id].location = entry.location;
+        }
+      });
+    };
+
+    return map;
+
+  } catch (error) {
+    const json = error?.options?.json || null;
+    throw new StripesHubError(
+      `Discovery fetch error at ${url}`,
+      { json, url, id: 'stripes-hub.error.discoveryFetch', cause: error }
+    );
   };
 
-  return map;
 };
 
 /**

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -168,30 +168,27 @@ export const setUnauthorizedPathToSession = (pathname) => {
 export const getUnauthorizedPathFromSession = () => sessionStorage.getItem(UNAUTHORIZED_PATH);
 
 /**
- * ffetch (folio-fetch)
- * Wrapper around fetch to include Okapi headers and error handling. Throws
+ * authenticatedFetch
+ * Wrapper around fetch to include headers headers and error handling. Throws
  * if response is not ok. Returns parsed JSON response.
  *
  * @param {string} url URL to retrieve
  * @param {string} tenant tenant for x-okapi-tenant header
  * @returns {Promise} resolves to the JSON response
  */
-const ffetch = async (url, tenant) => {
+const authenticatedFetch = async (url, tenant) => {
   const res = await fetch(url, {
     headers: getHeaders(tenant),
     credentials: 'include',
     mode: 'cors',
   });
 
-  // TODO: should ffetch be responsible for throwing this generic error
-  // or should the caller trap and rethrow with more context? e.g. "entitlement error", "discovery error"?
-  if (!res.ok) {
-    const json = await res.json();
-    throw new StripesHubError(`Fetch to ${url} failed: ${res.status} ${res.statusText}`, { json, url });
+  const json = await res.json();
+  if (res.ok) {
+    return json;
   }
 
-  const json = await res.json();
-  return json;
+  throw new StripesHubError(`Fetch to ${url} failed: ${res.status} ${res.statusText}`, { json, url });
 }
 
 /**
@@ -206,7 +203,7 @@ export const fetchEntitlements = async (config, tenant) => {
   const url = `${config.gatewayUrl}/entitlements/${tenant}/applications`;
   try {
     const entitlement = {};
-    const json = await ffetch(url, tenant);
+    const json = await authenticatedFetch(url, tenant);
     const elist = json.applicationDescriptors;
     elist.forEach(application => {
       application.uiModules.forEach(module => {
@@ -298,7 +295,7 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
     const applicationIds = Array.from(new Set(Object.values(entitlement).map(mod => mod.applicationId)));
 
     for (const appId of applicationIds) {
-      const json = await ffetch(url, tenant);
+      const json = await authenticatedFetch(url, tenant);
       json.discovery.forEach(entry => {
         if (entitlement[entry.id]) {
           // TODO: use a categorical logger for this or omit it

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -238,10 +238,10 @@ export const fetchEntitlements = async (config, tenant) => {
  * @returns the converted object shaped like { interfaceA: '1.0 2.0', ... }
  */
 const interfaceArrayToKeyedObject = (arr) => {
-    return arr.reduce((acc, curr) => {
-        acc[curr.id] = curr.version;
-        return acc;
-    }, {});
+  return arr.reduce((acc, curr) => {
+    acc[curr.id] = curr.version;
+    return acc;
+  }, {});
 }
 
 /**
@@ -300,13 +300,12 @@ const fetchCustomDiscovery = async (config, tenant, entitlement) => {
  * @returns {Promise<object>} map of entitlement and discovery data, keyed by module ID
  */
 const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
-  const url = `${config.gatewayUrl}/applications/${appId}/discovery?limit=500`;
+  let url = null;
   try {
     const map = {};
-
     const applicationIds = Array.from(new Set(Object.values(entitlement).map(mod => mod.applicationId)));
-
     for (const appId of applicationIds) {
+      url = `${config.gatewayUrl}/applications/${appId}/discovery?limit=500`;
       const json = await authenticatedFetch(url, tenant);
       json.discovery.forEach(entry => {
         if (entitlement[entry.id]) {
@@ -318,7 +317,6 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
     };
 
     return map;
-
   } catch (error) {
     const json = error?.options?.json || null;
     throw new StripesHubError(
@@ -326,7 +324,6 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
       { json, url, id: 'stripes-hub.error.discoveryFetch', cause: error }
     );
   };
-
 };
 
 /**

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -310,8 +310,7 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
       const json = await authenticatedFetch(url, tenant);
       json.discovery.forEach(entry => {
         if (entitlement[entry.id]) {
-          // TODO: use a categorical logger for this or omit it
-          console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
+          // maybe log sth like `Adding discovery data for ${entry.id} => ${entry.location}`
           map[entry.id] = entitlement[entry.id];
           map[entry.id].location = entry.location;
         }

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -200,7 +200,7 @@ const ffetch = async (url, tenant) => {
  * @param {string} tenant
  * @returns {Promise<map>} map of entitlement data, keyed by module ID
  */
-const fetchEntitlements = async (config, tenant) => {
+export const fetchEntitlements = async (config, tenant) => {
   const entitlement = {};
   const json = await ffetch(`${config.gatewayUrl}/entitlements/${tenant}/applications`, tenant);
   const elist = json.applicationDescriptors;
@@ -304,7 +304,7 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
  * @param {map} entitlement
  * @returns {Promise<object>} map of entitlement and discovery data, keyed by module ID
  */
-const fetchDiscovery = async (config, tenant, entitlement) => {
+export const fetchDiscovery = async (config, tenant, entitlement) => {
   // Ordinarily, the discovery API query goes against the same gateway as
   // any other API query. Running module-federation locally, however, requires
   // running a local discovery server, and routing discovery API queries only
@@ -329,7 +329,7 @@ const fetchDiscovery = async (config, tenant, entitlement) => {
  * Dynamically load stripes CSS and JS assets using the build's manifest.json.
  * Stripes will bootstrap itself once its JS is loaded.
  */
-const loadStripes = async (stripesCore) => {
+export const loadStripes = async (stripesCore) => {
   try {
     console.log('x')
     const manifestJSON = await fetch(`${stripesCore.location}/manifest.json`);
@@ -369,48 +369,6 @@ const loadStripes = async (stripesCore) => {
     console.error('error loading stripes', error.message); // eslint-disable-line no-console
     throw error;
   }
-}
-
-/**
- * initStripes
- * Fetch entitlements and discovery data, then cache it in local storage.
- * Pluck stripes from the discovery data and purge it from the cache (we don't
- * want stripes to try to load itself) and then load stripes.
- *
- * Stripes is keyed by folio_stripes-core in the entitlement data, which is
- * composed of Application Descriptors, themselves composed of Module
- * Descriptors. IOW, entitlement data only contains modules that have MDs.
- * Since Stripes itself does not contain an MD but stripes-core does, we take
- * advantage of that fact, using the folio_stripes-core key in entitlement and
- * discovery data to find stripes' location.
- *
- * @param {object} config
- * @param {object} branding
- * @param {string} tenant
- * @returns {Promise<void>} resolves when stripes is initialized
- */
-export const initStripes = async (config, branding, tenant) => {
-  const entitlement = await fetchEntitlements(config, tenant);
-  const discovery = await fetchDiscovery(config, tenant, entitlement);
-
-  const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
-  if (stripesCore) {
-    await localforage.setItem(DISCOVERY_URL_KEY, config.discoveryUrl ?? config.gatewayUrl);
-    await localforage.setItem(HOST_APP_NAME, HOST_APP_NAME);
-    await localforage.setItem(FOLIO_CONFIG_KEY, config);
-    await localforage.setItem(FOLIO_BRANDING_KEY, branding);
-    await localforage.setItem(HOST_LOCATION_KEY, stripesCore.location);
-
-    // REMOTE_LIST_KEY stores the list of apps that stripes will load,
-    // so we have to remove stripes from that list. Otherwise, Malkovich.
-    // Malkovich Malkovich Malkovich? Malkovich!
-    await localforage.setItem(REMOTE_LIST_KEY, Object.values(discovery).filter(module => module.name !== 'folio_stripes-core'));
-
-    await loadStripes(stripesCore);
-    return Promise.resolve();
-  }
-
-  throw new Error('Stripes core module not found in discovery data');
 }
 
 /**

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -54,6 +54,14 @@ export const getHeaders = (tenant, token) => {
   };
 };
 
+export class StripesHubError extends Error {
+  constructor(message, options) {
+    super(message, options);
+
+    this.options = options;
+  }
+}
+
 /**
  * getOIDCRedirectUri
  * Construct OIDC redirect URI based on current location, tenant, and client ID.
@@ -232,7 +240,20 @@ const fetchEntitlements = async (config, tenant) => {
 const fetchCustomDiscovery = async (config, tenant, entitlement) => {
   const map = {};
 
-  const json = await ffetch(`${config.discoveryUrl}`, tenant);
+  // const json = await ffetch(`${config.discoveryUrl}`, tenant);
+  const res = await fetch(`${config.discoveryUrl}`, {
+    headers: getHeaders(tenant),
+    // credentials: 'include',
+    mode: 'cors',
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Fetch to ${url} failed: ${res.status} ${res.statusText} - ${text}`);
+  }
+
+  const json = await res.json();
+
   json.discovery.forEach(entry => {
     console.log(`Adding discovery data for ${entry.id} => ${entry.location}`);
     map[entry.id] = entry;
@@ -309,38 +330,45 @@ const fetchDiscovery = async (config, tenant, entitlement) => {
  * Stripes will bootstrap itself once its JS is loaded.
  */
 const loadStripes = async (stripesCore) => {
-  const manifestJSON = await fetch(`${stripesCore.location}/manifest.json`);
-  const manifest = await manifestJSON.json();
+  try {
+    console.log('x')
+    const manifestJSON = await fetch(`${stripesCore.location}/manifest.json`);
+    if (!manifestJSON.ok) {
+      throw new Error(`Failed to fetch manifest: ${stripesCore.location}/manifest.json`);
+    }
+    const manifest = await manifestJSON.json();
 
-  // collect imports...
-  const jsImports = new Set();
-  const cssImports = new Set();
-  Object.keys(manifest.entrypoints).forEach((entry) => {
-    manifest.entrypoints[entry].imports.forEach((imp) => {
-      if (imp.endsWith('.js')) {
-        jsImports.add(imp);
-      } else if (imp.endsWith('.css')) {
-        cssImports.add(imp);
-      }
+    // collect imports...
+    const jsImports = new Set();
+    const cssImports = new Set();
+    Object.keys(manifest.entrypoints).forEach((entry) => {
+      manifest.entrypoints[entry].imports.forEach((imp) => {
+        if (imp.endsWith('.js')) {
+          jsImports.add(imp);
+        } else if (imp.endsWith('.css')) {
+          cssImports.add(imp);
+        }
+      });
     });
-  });
 
-  cssImports.forEach((cssRef) => {
-    const cssFile = manifest.assets[cssRef].file
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = `${stripesCore.location}${cssFile}`;
-    document.head.appendChild(link);
-  });
+    cssImports.forEach((cssRef) => {
+      const cssFile = manifest.assets[cssRef].file
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = `${stripesCore.location}${cssFile}`;
+      document.head.appendChild(link);
+    });
 
-  jsImports.forEach((jsRef) => {
-    const jsFile = manifest.assets[jsRef].file;
-    import(/* webpackIgnore: true */ `${stripesCore.location}${jsFile}`);
-  });
-
-  // compilers get cranky in functions marked async that don't await anything,
-  // so we have to return _something_ here.
-  return Promise.resolve();
+    for (const jsRef of jsImports) {
+      const jsFile = manifest.assets[jsRef].file;
+      console.log(`Loading stripes asset ${stripesCore.location}${jsFile}...`)
+      await import(/* webpackIgnore: true */ `${stripesCore.location}${jsFile}`);
+    }
+  } catch (error) {
+    console.log('ccccccccc')
+    console.error('error loading stripes', error.message); // eslint-disable-line no-console
+    throw error;
+  }
 }
 
 /**
@@ -378,10 +406,11 @@ export const initStripes = async (config, branding, tenant) => {
     // Malkovich Malkovich Malkovich? Malkovich!
     await localforage.setItem(REMOTE_LIST_KEY, Object.values(discovery).filter(module => module.name !== 'folio_stripes-core'));
 
-    return loadStripes(stripesCore);
+    await loadStripes(stripesCore);
+    return Promise.resolve();
   }
 
-  throw new Error('Could not find stripes-core in discovery data');
+  throw new Error('Stripes core module not found in discovery data');
 }
 
 /**

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -237,7 +237,7 @@ export const fetchEntitlements = async (config, tenant) => {
  * Fetch discovery data with a single query and return it in a map keyed by id.
  * IGNORE the entitlement data altogether! The local discovery service is, in
  * fact, an entitlement-and-discovery service, and so we allow its response for
- * both entitlement and discover data to be the authoritative response.
+ * both entitlement and discovery data to be the authoritative response.
  *
  * @param {object} config config
  * @param {string} tenant

--- a/src/translations/stripes-hub/en_US.json
+++ b/src/translations/stripes-hub/en_US.json
@@ -1,0 +1,15 @@
+{
+  "StripesHub.loadingEntitlements": "loading entitlements ...",
+  "StripesHub.loadingDiscovery": "loading discovery ...",
+  "StripesHub.loadingSession": "loading session ...",
+  "StripesHub.loadingStripes": "loading Stripes ...",
+
+  "OidcLanding.initializingSession": "Initializing session ...",
+  "PreLoginLanding.tenantChoose": "Choose your tenant",
+  "PreLoginLanding.tenantLibrary": "Tenant / Library",
+  "PreLoginLanding.button.continue": "Continue",
+  "FatalError.headline": "Rats. You successfully signed in, but FOLIO failed to load because of an error 😢",
+  "FatalError.tryAgain": "Try again",
+  "FatalError.logout": "Log out"
+
+}

--- a/src/translations/stripes-hub/en_US.json
+++ b/src/translations/stripes-hub/en_US.json
@@ -1,8 +1,8 @@
 {
-  "StripesHub.loadingEntitlements": "loading entitlements ...",
-  "StripesHub.loadingDiscovery": "loading discovery ...",
-  "StripesHub.loadingSession": "loading session ...",
-  "StripesHub.loadingStripes": "loading Stripes ...",
+  "StripesHub.loadingEntitlements": "Loading entitlements ...",
+  "StripesHub.loadingDiscovery": "Loading discovery ...",
+  "StripesHub.loadingSession": "Loading session ...",
+  "StripesHub.loadingStripes": "Loading Stripes ...",
 
   "OidcLanding.initializingSession": "Initializing session ...",
   "PreLoginLanding.tenantChoose": "Choose your tenant",
@@ -10,6 +10,10 @@
   "PreLoginLanding.button.continue": "Continue",
   "FatalError.headline": "Rats. You successfully signed in, but FOLIO failed to load because of an error 😢",
   "FatalError.tryAgain": "Try again",
-  "FatalError.logout": "Log out"
+  "FatalError.logout": "Log out",
 
+  "error.entitlementFetch": "Entitlement fetch error at {url}",
+  "error.discoveryFetch": "Discovery fetch error at {url}",
+  "error.sessionFetch": "Session fetch error at {url}",
+  "error.tokenExchangeFailure": "Token exchange failed"
 }

--- a/src/translations/stripes-hub/en_US.json
+++ b/src/translations/stripes-hub/en_US.json
@@ -4,11 +4,11 @@
   "StripesHub.loadingSession": "Loading session ...",
   "StripesHub.loadingStripes": "Loading Stripes ...",
 
-  "OidcLanding.initializingSession": "Initializing session ...",
+  "OidcLanding.initializingSession": "Loading session ...",
   "PreLoginLanding.tenantChoose": "Choose your tenant",
   "PreLoginLanding.tenantLibrary": "Tenant / Library",
   "PreLoginLanding.button.continue": "Continue",
-  "FatalError.headline": "Rats. You successfully signed in, but FOLIO failed to load because of an error 😢",
+  "FatalError.headline": "Oh, snap. You successfully signed in, but FOLIO failed to load because of an error 😢. If the problem persists please contact your system administrator.",
   "FatalError.tryAgain": "Try again",
   "FatalError.logout": "Log out",
 
@@ -16,5 +16,5 @@
   "error.discoveryFetch": "Discovery fetch error at {url}",
   "error.sessionFetch": "Session fetch error at {url}",
   "error.tokenExchangeFailure": "Token exchange failed",
-  "error.stripesFetchFailure": "Stripes load failed at {url}"
+  "error.stripesFetchFailure": "Stripes fetch error at {url}"
 }

--- a/src/translations/stripes-hub/en_US.json
+++ b/src/translations/stripes-hub/en_US.json
@@ -15,5 +15,6 @@
   "error.entitlementFetch": "Entitlement fetch error at {url}",
   "error.discoveryFetch": "Discovery fetch error at {url}",
   "error.sessionFetch": "Session fetch error at {url}",
-  "error.tokenExchangeFailure": "Token exchange failed"
+  "error.tokenExchangeFailure": "Token exchange failed",
+  "error.stripesFetchFailure": "Stripes load failed at {url}"
 }


### PR DESCRIPTION
Any error that occurs during session setup, entitlement or discovery API requests, or related to loading Stripes (the host application) is fatal: if Stripes cannot load, nothing can load. Trap these errors. Display something friendly for the user in the browser. Log something helpful for the developer in the console.

The user may be in a delicate state here: they have successfully authenticated but have not successfully started a session. Thus, the error page includes two buttons:
1. reload: maybe the failure was the result of a temporary blip and entitlement/discovery will run correctly
2. logout: make an API request to `/logout` to destroy any cookies and then redirect back to /, allowing login to begin again

Errors are logged to the console in the catch clause where they are first trapped. If the fetch succeeds but the response-code is not ok, call `await response.json()` there in the catch clause (there's no harm; that function is already async by definition) and include it in the error that is thrown, simplifying parsing in the error page. (Attempting to extract the response json in `useEffect` is fraught since a Response object can only be processed once but effects run twice in dev-mode.)

https://github.com/user-attachments/assets/d2aff452-1d15-439b-9609-39f418aebd68

https://github.com/user-attachments/assets/1f6c9eed-327a-4dec-8b34-e49d9e72f5ba

Refs [STHUB-11](https://folio-org.atlassian.net/browse/STHUB-11), [STHUB-12](https://folio-org.atlassian.net/browse/STHUB-12), [STHUB-13](https://folio-org.atlassian.net/browse/STHUB-13), [STHUB-14](https://folio-org.atlassian.net/browse/STHUB-14), [STHUB-15](https://folio-org.atlassian.net/browse/STHUB-15)