### PR TITLE
[STHUB-18] Restore putting branding and config in local storage

### DIFF
--- a/src/hooks/useInitSession.js
+++ b/src/hooks/useInitSession.js
@@ -169,10 +169,11 @@ const useInitSession = (config, branding, loginUrl) => {
       console.log({ session, entitlement, discovery });
       const stripesCore = Object.values(discovery).find((entry) => entry.name === 'folio_stripes-core');
       if (stripesCore) {
+        localStorage.setItem(FOLIO_CONFIG_KEY, JSON.stringify(config));
+        localStorage.setItem(FOLIO_BRANDING_KEY, JSON.stringify(branding));
+
         await localforage.setItem(DISCOVERY_URL_KEY, config.discoveryUrl ?? config.gatewayUrl);
         await localforage.setItem(HOST_APP_NAME, HOST_APP_NAME);
-        await localforage.setItem(FOLIO_CONFIG_KEY, config);
-        await localforage.setItem(FOLIO_BRANDING_KEY, branding);
         await localforage.setItem(HOST_LOCATION_KEY, stripesCore.location);
 
         // REMOTE_LIST_KEY stores the list of apps that stripes will load,


### PR DESCRIPTION
This was introduced in commit 0bdbc0b and was accidentally reverted in 268356f.