### PR TITLE
Modernize react-intl usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [STHUB-1](https://folio-org.atlassian.net/browse/STHUB-1) Added config and logic for session validation. If session is invalid, redirect to keycloak login page.
 * [STHUB-18](https://folio-org.atlassian.net/browse/STHUB-18) Store config and branding data from index.html in localstorage for consumption by stripes, which may be built independently.
 * [STHUB-11](https://folio-org.atlassian.net/browse/STHUB-11) Trap errors during entitlement, discovery, and the loading of Stripes.
+* [STHUB-19](https://folio-org.atlassian.net/browse/STHUB-19) Enhance Localization Support with modern `react-intl` usage and set up translations via `folio-translations`.
 
 ## 1.0.0
 

--- a/src/FatalError.js
+++ b/src/FatalError.js
@@ -2,6 +2,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { Button, Col, Row } from './StripesComponents';
+import { sharedMessages } from './constants/sharedMessages';
 import StripesTemplate from './StripesTemplate';
 import styles from './index.css';
 
@@ -37,7 +38,7 @@ function FatalError({ branding, config, error }) {
     <StripesTemplate branding={branding}>
       <Row center="xs">
         <Col xs={12}>
-          <h1><FormattedMessage id="stripes-hub.FatalError.headline" /></h1>
+          <h1><FormattedMessage {...sharedMessages.fatalErrorHeadline} /></h1>
           <h2>{l10nMessage}</h2>
           <h3>{message}</h3>
           <h3>{subMessage}</h3>
@@ -49,7 +50,7 @@ function FatalError({ branding, config, error }) {
             className={styles.submitButton}
             onClick={handleReload}
           >
-            <FormattedMessage id="stripes-hub.FatalError.tryAgain" />
+            <FormattedMessage {...sharedMessages.fatalErrorTryAgain} />
           </Button>
         </Col>
         <Col xs={6}>
@@ -57,7 +58,7 @@ function FatalError({ branding, config, error }) {
             className={styles.submitButton}
             onClick={handleLogout}
           >
-            <FormattedMessage id="stripes-hub.FatalError.logout" />
+            <FormattedMessage {...sharedMessages.fatalErrorLogout} />
           </Button>
         </Col>
       </Row>

--- a/src/OidcLanding.js
+++ b/src/OidcLanding.js
@@ -10,6 +10,7 @@ import {
   storeCurrentTenant,
 } from './loginServices';
 
+import { sharedMessages } from './constants/sharedMessages';
 import useExchangeCode from './hooks/useExchangeCode';
 import FatalError from './FatalError';
 import StripesTemplate from './StripesTemplate';
@@ -68,8 +69,8 @@ const OidcLanding = ({ branding, config }) => {
     <StripesTemplate branding={branding}>
       <div data-test-saml-success>
         <div>
-          {isLoading && <h1><FormattedMessage id="stripes-hub.OidcLanding.validatingAuthenticationToken" /></h1>}
-          {tokenData && <h1><FormattedMessage id="stripes-hub.OidcLanding.initializingSession" /></h1>}
+          {isLoading && <h1><FormattedMessage {...sharedMessages.validatingAuthenticationToken} /></h1>}
+          {tokenData && <h1><FormattedMessage {...sharedMessages.initializingSession} /></h1>}
         </div>
       </div>
     </StripesTemplate>

--- a/src/PreLoginLanding.js
+++ b/src/PreLoginLanding.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 
 import { Button, Col, Row, Select } from './StripesComponents';
 import { getLoginUrl, getCurrentTenant } from './loginServices';
-import styles from './index.css';
 import StripesTemplate from './StripesTemplate';
+import { sharedMessages } from './constants/sharedMessages';
+import styles from './index.css';
 
 export function sortedTenantOptions(tenantOptions) {
   return Object.values(tenantOptions)
@@ -18,7 +19,7 @@ export function sortedTenantOptions(tenantOptions) {
 }
 
 function PreLoginLanding({ branding, config, onSelectTenant, tenantOptions }) {
-  const intl = useIntl();
+  const { $t } = useIntl();
 
   const options = sortedTenantOptions(tenantOptions);
 
@@ -50,17 +51,17 @@ function PreLoginLanding({ branding, config, onSelectTenant, tenantOptions }) {
       <Row center="xs">
         <Col xs={3}>
           <Select
-            label={intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantLibrary' })}
+            label={$t(sharedMessages.tenantLibrary)}
             defaultValue=""
             onChange={handleChangeTenant}
-            dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantChoose' }) }]}
+            dataOptions={[...options, { value: '', label: $t(sharedMessages.tenantChoose) }]}
           />
           <Button
             className={styles.submitButton}
             disabled={isButtonDisabled}
             onClick={redirectToLogin}
           >
-            {intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.button.continue' })}
+            {$t(sharedMessages.continueButton)}
           </Button>
         </Col>
       </Row>

--- a/src/StripesHub.js
+++ b/src/StripesHub.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import useInitSession from './hooks/useInitSession';
+import { sharedMessages } from './constants/sharedMessages';
 import { urlPaths } from './constants';
 import FatalError from './FatalError';
 import { Col, Row } from './StripesComponents';
@@ -19,8 +20,9 @@ function StripesHub({ branding, config }) {
     sessionError,
   } = useInitSession(config, branding, urlPaths.AUTHN_LOGIN);
 
-  if (discoveryError || entitlementError || stripesError || sessionError) {
-    const error = discoveryError || entitlementError || stripesError || sessionError;
+  const error = discoveryError || entitlementError || stripesError || sessionError;
+
+  if (error) {
     return <FatalError branding={branding} config={config} error={error} />;
   }
 
@@ -29,10 +31,10 @@ function StripesHub({ branding, config }) {
       <Row center="xs">
         <Col xs={12}>
           <div data-testid="StripesHub">
-            {isLoadingEntitlement && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingEntitlements" /></h1>}
-            {isLoadingDiscovery && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingDiscovery" /></h1>}
-            {isLoadingSession && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingSession" /></h1>}
-            {isLoadingStripes && <h1><FormattedMessage id="stripes-hub.StripesHub.loadingStripes" /></h1>}
+            {isLoadingEntitlement && <h1><FormattedMessage {...sharedMessages.loadingEntitlements} /></h1>}
+            {isLoadingDiscovery && <h1><FormattedMessage {...sharedMessages.loadingDiscovery} /></h1>}
+            {isLoadingSession && <h1><FormattedMessage {...sharedMessages.loadingSession} /></h1>}
+            {isLoadingStripes && <h1><FormattedMessage {...sharedMessages.loadingStripes} /></h1>}
           </div>
         </Col>
       </Row>

--- a/src/constants/sharedMessages.js
+++ b/src/constants/sharedMessages.js
@@ -1,0 +1,76 @@
+import { defineMessages } from 'react-intl';
+
+export const sharedMessages = defineMessages({
+  errorEntitlementFetch: {
+    id: 'stripes-hub.error.entitlementFetch',
+    defaultMessage: 'Entitlement fetch error at {url}',
+  },
+  errorDiscoveryFetch: {
+    id: 'stripes-hub.error.discoveryFetch',
+    defaultMessage: 'Discovery fetch error at {url}',
+  },
+  errorSessionFetch: {
+    id: 'stripes-hub.error.sessionFetch',
+    defaultMessage: 'Session fetch error at {url}',
+  },
+  errorTokenExchangeFailure: {
+    id: 'stripes-hub.error.tokenExchangeFailure',
+    defaultMessage: 'Token exchange failed',
+  },
+  errorStripesFetchFailure: {
+    id: 'stripes-hub.error.stripesFetchFailure',
+    defaultMessage: 'Stripes fetch error at {url}',
+  },
+  oidcOtpMissingCode: {
+    id: 'stripes-hub.oidc.otp.missingCode',
+    defaultMessage: 'Missing code in the URL',
+  },
+  fatalErrorHeadline: {
+    id: 'stripes-hub.FatalError.headline',
+    defaultMessage: 'Oh, snap. You successfully signed in, but FOLIO failed to load because of an error 😢. If the problem persists please contact your system administrator.',
+  },
+  fatalErrorTryAgain: {
+    id: 'stripes-hub.FatalError.tryAgain',
+    defaultMessage: 'Try again',
+  },
+  fatalErrorLogout: {
+    id: 'stripes-hub.FatalError.logout',
+    defaultMessage: 'Logout',
+  },
+  initializingSession: {
+    id: 'stripes-hub.OidcLanding.initializingSession',
+    defaultMessage: 'Initializing session...',
+  },
+  validatingAuthenticationToken: {
+    id: 'stripes-hub.OidcLanding.validatingAuthenticationToken',
+    defaultMessage: 'Validating authentication token...',
+  },
+  tenantLibrary: {
+    id: 'stripes-hub.PreLoginLanding.tenantLibrary',
+    defaultMessage: 'Tenant / Library',
+  },
+  tenantChoose: {
+    id: 'stripes-hub.PreLoginLanding.tenantChoose',
+    defaultMessage: 'Choose your tenant',
+  },
+  continueButton: {
+    id: 'stripes-hub.PreLoginLanding.button.continue',
+    defaultMessage: 'Continue',
+  },
+  loadingEntitlements: {
+    id: 'stripes-hub.StripesHub.loadingEntitlements',
+    defaultMessage: 'Loading entitlements ...',
+  },
+  loadingDiscovery: {
+    id: 'stripes-hub.StripesHub.loadingDiscovery',
+    defaultMessage: 'Loading discovery ...',
+  },
+  loadingSession: {
+    id: 'stripes-hub.StripesHub.loadingSession',
+    defaultMessage: 'Loading session ...',
+  },
+  loadingStripes: {
+    id: 'stripes-hub.StripesHub.loadingStripes',
+    defaultMessage: 'Loading Stripes ...',
+  },
+});

--- a/src/constants/sharedMessages.js
+++ b/src/constants/sharedMessages.js
@@ -3,74 +3,56 @@ import { defineMessages } from 'react-intl';
 export const sharedMessages = defineMessages({
   errorEntitlementFetch: {
     id: 'stripes-hub.error.entitlementFetch',
-    defaultMessage: 'Entitlement fetch error at {url}',
   },
   errorDiscoveryFetch: {
     id: 'stripes-hub.error.discoveryFetch',
-    defaultMessage: 'Discovery fetch error at {url}',
   },
   errorSessionFetch: {
     id: 'stripes-hub.error.sessionFetch',
-    defaultMessage: 'Session fetch error at {url}',
   },
   errorTokenExchangeFailure: {
     id: 'stripes-hub.error.tokenExchangeFailure',
-    defaultMessage: 'Token exchange failed',
   },
   errorStripesFetchFailure: {
     id: 'stripes-hub.error.stripesFetchFailure',
-    defaultMessage: 'Stripes fetch error at {url}',
   },
   oidcOtpMissingCode: {
     id: 'stripes-hub.oidc.otp.missingCode',
-    defaultMessage: 'Missing code in the URL',
   },
   fatalErrorHeadline: {
     id: 'stripes-hub.FatalError.headline',
-    defaultMessage: 'Oh, snap. You successfully signed in, but FOLIO failed to load because of an error 😢. If the problem persists please contact your system administrator.',
   },
   fatalErrorTryAgain: {
     id: 'stripes-hub.FatalError.tryAgain',
-    defaultMessage: 'Try again',
   },
   fatalErrorLogout: {
     id: 'stripes-hub.FatalError.logout',
-    defaultMessage: 'Logout',
   },
   initializingSession: {
     id: 'stripes-hub.OidcLanding.initializingSession',
-    defaultMessage: 'Initializing session...',
   },
   validatingAuthenticationToken: {
     id: 'stripes-hub.OidcLanding.validatingAuthenticationToken',
-    defaultMessage: 'Validating authentication token...',
   },
   tenantLibrary: {
     id: 'stripes-hub.PreLoginLanding.tenantLibrary',
-    defaultMessage: 'Tenant / Library',
   },
   tenantChoose: {
     id: 'stripes-hub.PreLoginLanding.tenantChoose',
-    defaultMessage: 'Choose your tenant',
   },
   continueButton: {
     id: 'stripes-hub.PreLoginLanding.button.continue',
-    defaultMessage: 'Continue',
   },
   loadingEntitlements: {
     id: 'stripes-hub.StripesHub.loadingEntitlements',
-    defaultMessage: 'Loading entitlements ...',
   },
   loadingDiscovery: {
     id: 'stripes-hub.StripesHub.loadingDiscovery',
-    defaultMessage: 'Loading discovery ...',
   },
   loadingSession: {
     id: 'stripes-hub.StripesHub.loadingSession',
-    defaultMessage: 'Loading session ...',
   },
   loadingStripes: {
     id: 'stripes-hub.StripesHub.loadingStripes',
-    defaultMessage: 'Loading Stripes ...',
   },
 });

--- a/src/hooks/useExchangeCode.js
+++ b/src/hooks/useExchangeCode.js
@@ -2,10 +2,11 @@ import { useQuery } from 'react-query';
 import { useIntl } from 'react-intl';
 import noop from 'lodash/noop';
 
+import { sharedMessages } from '../constants/sharedMessages';
 import { getLoginTenant, getHeaders, StripesHubError } from '../loginServices';
 
 const useExchangeCode = (config, initSession = noop) => {
-  const intl = useIntl();
+  const { $t } = useIntl();
   const urlParams = new URLSearchParams(globalThis.location.search);
   const code = urlParams.get('code');
   const loginTenant = getLoginTenant();
@@ -43,7 +44,7 @@ const useExchangeCode = (config, initSession = noop) => {
         }
       }
 
-      throw intl.formatMessage({ id: 'stripes-core.oidc.otp.missingCode' });
+      throw $t(sharedMessages.oidcOtpMissingCode);
     },
     {
       retry: false,

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import AuthnLogin from './AuthnLogin';
 import StripesHub from './StripesHub';
 import OidcLanding from './OidcLanding';
 import { urlPaths } from './constants';
-import rawTranslations from './translations/stripes-hub/en_US.json';
+import { loadTranslations } from './loadTranslations';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 const config = FOLIO_CONFIG || {}; // eslint-disable-line no-undef
@@ -16,6 +16,9 @@ const branding = BRANDING_GLOBAL || {}; // eslint-disable-line no-undef
 const AuthnLoginComponent = () => <AuthnLogin config={config} branding={branding} />;
 const OidcLandingComponent = () => <OidcLanding config={config} branding={branding} />;
 const StripesHubComponent = () => <StripesHub config={config} branding={branding} />;
+
+const locale = config.locale || navigator.language || 'en-US';
+const rawTranslations = loadTranslations(locale);
 
 const reactQueryClient = createReactQueryClient();
 const pathName = globalThis.location.pathname;
@@ -40,7 +43,7 @@ switch (pathName) {
 root.render(
   <React.StrictMode>
     <QueryClientProvider client={reactQueryClient}>
-      <IntlProvider locale={config.locale || navigator.language || 'en-US'} messages={translations} >
+      <IntlProvider locale={locale} messages={translations} >
         <LandingComponent />
       </IntlProvider>
     </QueryClientProvider>

--- a/src/loadTranslations.js
+++ b/src/loadTranslations.js
@@ -1,0 +1,26 @@
+const TRANSLATION_PATH = './translations/stripes-hub';
+const DEFAULT_LOCALE = 'en-US';
+
+/**
+ * Loads translations for the specified locale.
+ * If the translations for the specified locale are not found, it falls back to the default locale.
+ * @param {*} locale the locale to load translations for.
+ * @returns translations for the specified locale or default locale if not found.
+ */
+export const loadTranslations = (locale) => (async function () {
+  let translations = {};
+  
+  try {
+    translations = await import(/* webpackIgnore: true */ `${TRANSLATION_PATH}/${locale}.json`);
+  } catch (e) {
+    console.warn(`Could not load translations for locale ${locale}, falling back to default locale ${DEFAULT_LOCALE}.`);
+
+    try {
+      translations = await import(/* webpackIgnore: true */ `${TRANSLATION_PATH}/${DEFAULT_LOCALE}.json`);
+    } catch (e) {
+      console.warn(`Could not load translations for default locale ${DEFAULT_LOCALE}. No translations will be available.`);
+    }
+  }
+
+  return translations;
+}());

--- a/src/loginServices.js
+++ b/src/loginServices.js
@@ -2,6 +2,7 @@ import localforage from 'localforage';
 import isObject from 'lodash/isObject';
 
 import { defaultErrors, urlPaths } from './constants';
+import { sharedMessages } from './constants/sharedMessages';
 
 /** name for the session key in local storage */
 export const SESSION_NAME = 'okapiSess';
@@ -188,7 +189,7 @@ export const fetchEntitlements = async (config, tenant) => {
     const json = error?.options?.json || null;
     throw new StripesHubError(
       `Entitlement fetch error at ${url}`,
-      { json, url, id: 'stripes-hub.error.entitlementFetch', cause: error }
+      { json, url, id: sharedMessages.errorEntitlementFetch.id, cause: error }
     );
   }
 };
@@ -244,7 +245,7 @@ const fetchCustomDiscovery = async (config, tenant) => {
 
   throw new StripesHubError(
     `Discovery fetch error at ${config.discoveryUrl}`,
-    { json, url: config.discoveryUrl, id: 'stripes-hub.error.discoveryFetch' }
+    { json, url: config.discoveryUrl, id: sharedMessages.errorDiscoveryFetch.id }
   );
 };
 
@@ -281,7 +282,7 @@ const fetchDefaultDiscovery = async (config, tenant, entitlement) => {
     const json = error?.options?.json || null;
     throw new StripesHubError(
       `Discovery fetch error at ${url}`,
-      { json, url, id: 'stripes-hub.error.discoveryFetch', cause: error }
+      { json, url, id: sharedMessages.errorDiscoveryFetch.id, cause: error }
     );
   };
 };
@@ -366,7 +367,7 @@ export const loadStripes = async (stripesCore) => {
     const json = error?.options?.json || null;
     throw new StripesHubError(
       `Stripes init error at ${url}`,
-      { json, url, id: 'stripes-hub.error.stripesFetchFailure', cause: error }
+      { json, url, id: sharedMessages.errorStripesFetchFailure.id, cause: error }
     );
   }
 }

--- a/src/translations/stripes-hub/en_US.json
+++ b/src/translations/stripes-hub/en_US.json
@@ -1,20 +1,25 @@
 {
-  "StripesHub.loadingEntitlements": "Loading entitlements ...",
-  "StripesHub.loadingDiscovery": "Loading discovery ...",
-  "StripesHub.loadingSession": "Loading session ...",
-  "StripesHub.loadingStripes": "Loading Stripes ...",
-
-  "OidcLanding.initializingSession": "Loading session ...",
-  "PreLoginLanding.tenantChoose": "Choose your tenant",
-  "PreLoginLanding.tenantLibrary": "Tenant / Library",
-  "PreLoginLanding.button.continue": "Continue",
-  "FatalError.headline": "Oh, snap. You successfully signed in, but FOLIO failed to load because of an error 😢. If the problem persists please contact your system administrator.",
-  "FatalError.tryAgain": "Try again",
-  "FatalError.logout": "Log out",
-
   "error.entitlementFetch": "Entitlement fetch error at {url}",
   "error.discoveryFetch": "Discovery fetch error at {url}",
   "error.sessionFetch": "Session fetch error at {url}",
   "error.tokenExchangeFailure": "Token exchange failed",
-  "error.stripesFetchFailure": "Stripes fetch error at {url}"
+  "error.stripesFetchFailure": "Stripes fetch error at {url}",
+
+  "oidc.otp.missingCode": "Missing code in the URL",
+
+  "FatalError.headline": "Oh, snap. You successfully signed in, but FOLIO failed to load because of an error 😢. If the problem persists please contact your system administrator.",
+  "FatalError.tryAgain": "Try again",
+  "FatalError.logout": "Log out",
+
+  "OidcLanding.initializingSession": "Loading session ...",
+  "OidcLanding.validatingAuthenticationToken": "Validating authentication token...",
+
+  "PreLoginLanding.tenantChoose": "Choose your tenant",
+  "PreLoginLanding.tenantLibrary": "Tenant / Library",
+  "PreLoginLanding.button.continue": "Continue",
+
+  "StripesHub.loadingEntitlements": "Loading entitlements ...",
+  "StripesHub.loadingDiscovery": "Loading discovery ...",
+  "StripesHub.loadingSession": "Loading session ...",
+  "StripesHub.loadingStripes": "Loading Stripes ..."
 }


### PR DESCRIPTION
Updating usage of `react-intl` to be more concise and be less prone to fat-finger typing errors with previously-used hard-coded strings.