### PR TITLE
STHUB-29 Style them screeens and scope them classNames

### DIFF
--- a/src/FatalError.jsx
+++ b/src/FatalError.jsx
@@ -46,7 +46,7 @@ function FatalError({ branding, config, error }) {
       <Row center="xs">
         <Col xs={6}>
           <Button
-            className={styles.submitButton}
+            className={`${styles.hubSubmitButton} ${styles.secondary}`}
             onClick={handleReload}
           >
             <FormattedMessage id="stripes-hub.FatalError.tryAgain" />
@@ -54,7 +54,7 @@ function FatalError({ branding, config, error }) {
         </Col>
         <Col xs={6}>
           <Button
-            className={styles.submitButton}
+            className={`${styles.hubSubmitButton} ${styles.secondary}`}
             onClick={handleLogout}
           >
             <FormattedMessage id="stripes-hub.FatalError.logout" />

--- a/src/ForgotPassword.jsx
+++ b/src/ForgotPassword.jsx
@@ -10,10 +10,10 @@ import {
   Button, Col, FieldLabel, Headline, Row, TextField
 } from './StripesComponents'
 import { brandingShape, configShape } from './constants';
+import styles from './index.module.css';
 
 const ForgotPassword = ({ branding, config }) => {
   const intl = useIntl();
-  const styles = {};
   const { name: tenant } = getLoginTenant(config);
 
   const { handleSubmit, didMutate } = useForgotPassword({ config, tenant });
@@ -30,6 +30,7 @@ const ForgotPassword = ({ branding, config }) => {
         onSubmit={handleSubmit}
         render={({ handleSubmit, pristine }) => (
           <form
+            className={styles.hubForm}
             data-form="forgot"
             onSubmit={handleSubmit}
           >
@@ -66,7 +67,7 @@ const ForgotPassword = ({ branding, config }) => {
                     component={TextField}
                     name="userInput"
                     type="text"
-                    inputClass={styles.loginInput}
+                    inputClass={styles.hubInput}
                     validationEnabled={false}
                     hasClearIcon={false}
                     autoCapitalize="none"
@@ -84,6 +85,7 @@ const ForgotPassword = ({ branding, config }) => {
                     id="clickable-login"
                     type="submit"
                     disabled={pristine || !tenant}
+                    className={styles.hubButton}
                   >
                     <FormattedMessage id="stripes-hub.button.continue" />
                   </Button>

--- a/src/ForgotUsername.jsx
+++ b/src/ForgotUsername.jsx
@@ -10,12 +10,12 @@ import { getLoginTenant } from './loginServices';
 import StripesTemplate from './StripesTemplate';
 import ForgotDidMutate from './ForgotDidMutate';
 import { brandingShape, configShape } from './constants';
+import styles from './index.module.css';
 
 const ForgotUsername = ({ branding, config }) => {
   const { name: tenant } = getLoginTenant(config);
   const { isError, handleSubmit, didMutate } = useForgotUsername({ config, tenant });
 
-  const styles = {};
   const intl = useIntl();
   const forgotUsernamePlaceholder = intl.formatMessage({ id: 'stripes-hub.ForgotUsername.placeholder' });
 
@@ -30,7 +30,7 @@ const ForgotUsername = ({ branding, config }) => {
         onSubmit={handleSubmit}
         render={({ handleSubmit, pristine }) => (
           <form
-            className={styles.form}
+            className={styles.hubForm}
             data-form="forgot"
             onSubmit={handleSubmit}
           >
@@ -69,7 +69,7 @@ const ForgotUsername = ({ branding, config }) => {
                     type="text"
                     marginBottom0
                     fullWidth
-                    inputClass={styles.loginInput}
+                    inputClass={styles.hubInput}
                     validationEnabled={false}
                     hasClearIcon={false}
                     autoCapitalize="none"
@@ -87,6 +87,7 @@ const ForgotUsername = ({ branding, config }) => {
                     id="clickable-login"
                     type="submit"
                     disabled={pristine || !tenant}
+                    className={styles.hubButton}
                   >
                     <FormattedMessage id="stripes-hub.button.continue" />
                   </Button>

--- a/src/PreLoginLanding.jsx
+++ b/src/PreLoginLanding.jsx
@@ -56,7 +56,7 @@ function PreLoginLanding({ branding, config, onSelectTenant, tenantOptions }) {
             dataOptions={[...options, { value: '', label: intl.formatMessage({ id: 'stripes-hub.PreLoginLanding.tenantChoose' }) }]}
           />
           <Button
-            className={styles.submitButton}
+            className={styles.hubButton}
             disabled={isButtonDisabled}
             onClick={redirectToLogin}
           >

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -9,13 +9,13 @@ import { urlPaths } from './constants';
 
 /**
  * Router component to determine which landing page to render based on the current path.
- * 
+ *
  * @param {*} config the configuration object.
  * @param {*} branding the branding configuration object.
  * @param {*} path the current path name.
  * @returns the landing page component to render.
  */
-const Router = ({config, branding, path}) => {
+const Router = ({ config, branding, path }) => {
   const props = { config, branding };
 
   switch (path) {
@@ -46,7 +46,7 @@ Router.propTypes = {
       src: PropTypes.string,
     }),
   }),
-  pathName: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
 };
 
 export default Router;

--- a/src/StripesComponents.jsx
+++ b/src/StripesComponents.jsx
@@ -7,7 +7,7 @@ AuthErrorsContainer.propTypes = {
 };
 
 export const Button = (props) => {
-  const { buttonRef, css, children, disabled, onClick, to, type, ref } = props;
+  const { buttonRef, className, css, children, disabled, onClick, to, type, ref } = props;
   return (
     <button
       type={type}
@@ -16,6 +16,7 @@ export const Button = (props) => {
       to={to}
       {...props}
       ref={buttonRef || ref}
+      className={className}
     >
       <span className={css?.inner}>
         {children}
@@ -29,6 +30,7 @@ Button.propTypes = {
     PropTypes.shape({ current: PropTypes.instanceOf(Element) })
   ]),
   children: PropTypes.node,
+  className: PropTypes.string,
   css: PropTypes.shape({
     inner: PropTypes.string,
   }),
@@ -42,14 +44,14 @@ Button.propTypes = {
   type: PropTypes.string,
 }
 
-export const Col = ({ children }) => <span>{children}</span>;
+export const Col = ({ children }) => <div className={styles.rowChild}>{children}</div>;
 Col.propTypes = {
   children: PropTypes.node,
 }
 
 export const FieldLabel = (props) => {
   const { children, ...rest } = props;
-  return <label htmlFor={props.htmlFor} {...rest}>{children}</label>;
+  return <label className={styles.label} htmlFor={props.htmlFor} {...rest}>{children}</label>;
 }
 FieldLabel.propTypes = {
   children: PropTypes.node,
@@ -71,8 +73,15 @@ OrganizationLogo.propTypes = {
   })
 }
 
-export const Row = ({ children }) => <div>{children}</div>;
+export const Row = ({ center, children }) => {
+  const rowClasses = [styles.row];
+  if (center) {
+    rowClasses.push(styles.center);
+  }
+  return <div className={rowClasses.join(' ')}>{children}</div>;
+};
 Row.propTypes = {
+  center: PropTypes.bool,
   children: PropTypes.node,
 }
 
@@ -92,7 +101,7 @@ export const Select = (props) => {
       );
     });
   }
-  return <select {...rest}>{options}</select>
+  return <select {...rest} className={styles.hubSelect}>{options}</select>
 }
 Select.propTypes = {
   children: PropTypes.node,
@@ -105,8 +114,9 @@ Select.propTypes = {
   value: PropTypes.string,
 }
 
-export const TextField = (props) => <div className={styles.formControl}><input {...props.input} id={props.id} /></div>;
+export const TextField = (props) => <div className={styles.formControl}><input {...props.input} className={props.inputClass} id={props.id} /></div>;
 TextField.propTypes = {
   id: PropTypes.string,
   input: PropTypes.object,
+  inputClass: PropTypes.string,
 }

--- a/src/StripesComponents.jsx
+++ b/src/StripesComponents.jsx
@@ -81,7 +81,7 @@ export const Row = ({ center, children }) => {
   return <div className={rowClasses.join(' ')}>{children}</div>;
 };
 Row.propTypes = {
-  center: PropTypes.bool,
+  center: PropTypes.string,
   children: PropTypes.node,
 }
 

--- a/src/StripesComponents.test.jsx
+++ b/src/StripesComponents.test.jsx
@@ -79,10 +79,10 @@ describe('StripesComponents', () => {
   });
 
   describe('Col', () => {
-    it('renders span element', () => {
+    it('renders div element', () => {
       const { container } = render(<Col>Content</Col>);
 
-      expect(container.querySelector('span')).toBeInTheDocument();
+      expect(container.querySelector('div')).toBeInTheDocument();
     });
 
     it('renders children', () => {

--- a/src/StripesTemplate.jsx
+++ b/src/StripesTemplate.jsx
@@ -6,7 +6,7 @@ import styles from './index.module.css';
 
 const StripesTemplate = ({ branding, children }) => {
   return (
-    <main style={{ width: '100%' }} className={styles.container}>
+    <main style={{ width: '100%' }} className={`${styles.container} ${styles.containerVars}`}>
       <div >
         <Row center="xs">
           <Col xs={12}>

--- a/src/index.module.css
+++ b/src/index.module.css
@@ -203,7 +203,7 @@ input[type="number"]::-webkit-inner-spin-button {
   float: left !important;
 }
 
-:root {
+.containerVars {
   --color-text: #000;
   --color-text-p2: rgba(0 0 0 / 62%);
   --color-border-form: rgba(0 0 0 / 42%);
@@ -412,7 +412,7 @@ input[type="number"]::-webkit-inner-spin-button {
   min-height: var(--control-min-size-desktop);
 }
 
-.hubForm .hubInput, .hubForm .hubSelect {
+.hubForm .hubInput {
   background: none;
   border: none;
   flex: 1;
@@ -425,6 +425,16 @@ input[type="number"]::-webkit-inner-spin-button {
   width: 100%;
 }
 
+.hubSelect {
+  height: 60px;
+  margin: 0;
+  min-width: 0;
+  padding: 15px;
+  outline: none;
+  width: 100%;
+  font-size: var(--font-size-medium);
+}
+
 .hubForm .label {
   display: block;
   width: 100%;
@@ -434,7 +444,7 @@ input[type="number"]::-webkit-inner-spin-button {
   margin: 1.5rem 0 1rem;
 }
 
-.hubForm .hubButton {
+.hubButton {
   appearance: none;
   align-items: center;
   background-color: var(--primary);

--- a/src/index.module.css
+++ b/src/index.module.css
@@ -315,6 +315,14 @@ input[type="number"]::-webkit-inner-spin-button {
   --message-banner-warning-border-color: var(--warn);
 }
 
+.flexRow {
+  display: flex;
+  gap: var(--gutter);
+  &.center {
+    justify-content: center;
+  }
+}
+
 .container {
   display: flex;
   justify-content: center;
@@ -340,7 +348,71 @@ input[type="number"]::-webkit-inner-spin-button {
   outline: 0;
 }
 
-form input {
+.hubSubmitButton {
+  &.secondary {
+    background-color: transparent;
+    border: 1px solid var(--primary);
+    color: var(--primary);
+  }
+
+  &:focus {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+
+    &:before {
+      position: absolute;
+      border-radius: 999px;
+      content: "";
+      background: var(--color-fill-focus);
+      border: 1px solid var(--color-border);
+      box-shadow: 0 0 0 2px var(--color-focus-shadow);
+      z-index: 3;
+      inset: 0;
+    }
+
+    &:after {
+      content: "";
+      opacity: 0;
+      visibility: hidden;
+      position: absolute;
+      transform: translateY(-50%) translate(-50%) scale(1);
+      min-width: 4px;
+      width: 4px;
+      height: 4px;
+      border-radius: 999px;
+      display: block;
+      z-index: 2;
+      background-color: #000;
+    }
+  }
+
+  position: relative;
+  padding: 0 var(--gutter-static);
+  text-align: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  color: var(--color-text);
+  border-radius: 999px;
+  transition: background-color .25s, color .25s, opacity .07s;
+  background-color: transparent;
+  border: transparent;
+  margin: 0 0 var(--gutter);
+  white-space: nowrap;
+  line-height: var(--line-height);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  outline: 0;
+  opacity: 1;
+  font-weight: var(--text-weight-button);
+  font-size: var(--font-size-medium);
+  min-height: var(--control-min-size-desktop);
+}
+
+.hubForm .hubInput, .hubForm .hubSelect {
   background: none;
   border: none;
   flex: 1;
@@ -353,7 +425,16 @@ form input {
   width: 100%;
 }
 
-form button {
+.hubForm .label {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-size: var(--font-size-large);
+  font-weight: var(--text-weight-headline-basis);
+  margin: 1.5rem 0 1rem;
+}
+
+.hubForm .hubButton {
   appearance: none;
   align-items: center;
   background-color: var(--primary);
@@ -362,7 +443,7 @@ form button {
   color: #fff;
   cursor: pointer;
   display: inline-flex;
-  font-size: var(--font-size-medium);
+  font-size: var(--font-size-large);
   font-weight: var(--text-weight-button);
   height: 60px;
   justify-content: center;
@@ -383,7 +464,7 @@ form button {
   -moz-appearance: none;
 }
 
-form button:disabled {
+.hubForm .hubButton:disabled {
   background-color: #ccc;
   border-color: #ccc;
   color: var(--color-text);
@@ -392,7 +473,7 @@ form button:disabled {
   transition: opacity ease-in-out .5s;
 }
 
-form input:focus, form button:focus {
+.hubForm .hubInput:focus, .hubForm .hubButton:focus {
   border: 1px solid var(--primary);
   box-shadow: inset 0 0 0 2px rgba(37 118 195 / 30%);
 }

--- a/src/index.module.css
+++ b/src/index.module.css
@@ -323,38 +323,7 @@ input[type="number"]::-webkit-inner-spin-button {
   }
 }
 
-.container {
-  display: flex;
-  justify-content: center;
-}
-
-.container > div {
-  max-width: 500px;
-  width: 100%;
-  padding: 30px 15px;
-  text-align: center;
-}
-
-.formControl {
-  align-items: center;
-  background-color: var(--color-fill-form-element);
-  border: 1px solid var(--color-border-form);
-  border-radius: 0;
-  color: var(--color-text);
-  display: flex;
-  letter-spacing: .4px;
-  min-height: var(--control-min-size-desktop);
-  width: 100%;
-  outline: 0;
-}
-
-.hubSubmitButton {
-  &.secondary {
-    background-color: transparent;
-    border: 1px solid var(--primary);
-    color: var(--primary);
-  }
-
+.interactive {
   &:focus {
     text-decoration: underline;
     text-decoration-thickness: 2px;
@@ -384,6 +353,41 @@ input[type="number"]::-webkit-inner-spin-button {
       z-index: 2;
       background-color: #000;
     }
+  }
+}
+
+.container {
+  display: flex;
+  justify-content: center;
+}
+
+.container > div {
+  max-width: 500px;
+  width: 100%;
+  padding: 30px 15px;
+  text-align: center;
+}
+
+.formControl {
+  align-items: center;
+  background-color: var(--color-fill-form-element);
+  border: 1px solid var(--color-border-form);
+  border-radius: 0;
+  color: var(--color-text);
+  display: flex;
+  letter-spacing: .4px;
+  min-height: var(--control-min-size-desktop);
+  width: 100%;
+  outline: 0;
+}
+
+.hubSubmitButton {
+  composes: interactive;
+
+  &.secondary {
+    background-color: transparent;
+    border: 1px solid var(--primary);
+    color: var(--primary);
   }
 
   position: relative;
@@ -445,6 +449,9 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 .hubButton {
+  composes: interactive;
+
+  position: relative;
   appearance: none;
   align-items: center;
   background-color: var(--primary);


### PR DESCRIPTION
Lookin stripes-y now.

I even styled the elusive tenant-select...
I also moved the variables to the `.container` element.
Element CSS variables are just as good as `:root` vars nowadays. 
Less to pollute the stripes space with...

I'm hot-potatoed by repetition... it's a field and a button, of course there's gonna be soooome repeats, DAD!

<img width="732" height="696" alt="image" src="https://github.com/user-attachments/assets/b780cf3c-342e-4948-ae95-00a9ece44afa" />
<img width="643" height="598" alt="image" src="https://github.com/user-attachments/assets/610c6270-12e1-439f-b307-7f7c9c24b3b0" />
<img width="725" height="649" alt="image" src="https://github.com/user-attachments/assets/26ba5619-d297-419b-97c9-06dc73995dd4" />



