### PR TITLE
[STHUB-37] Add copyleft license for lightningcss in README.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change history for stripes-hub
+
+## 1.0.0 IN PROGRESS
+
+* Initial application.
+* Added copyleft license for `lightningcss` in README. Refs STHUB-37.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Copyright (C) 2016-2026 The Open Library Foundation
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
+This software uses a copyleft (MPL-2.0) licensed software library: [lightningcss](https://github.com/parcel-bundler/lightningcss)
+
 ## Introduction
 
 stripes-hub orchestrates UI modules in a [module federation](https://webpack.js.org/concepts/module-federation/)


### PR DESCRIPTION
- Fulfills [STHUB-37](https://folio-org.atlassian.net/browse/STHUB-37).
- Also created `CHANGELOG`.